### PR TITLE
feat(infra): Add unified infrastructure scripts

### DIFF
--- a/services/infrastructure/README.md
+++ b/services/infrastructure/README.md
@@ -1,0 +1,92 @@
+# Infrastructure Setup
+
+Unified scripts and Docker configuration for Praxium's knowledge infrastructure.
+
+## Components
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| **Weaviate** | 8080 | Vector database for semantic search |
+| **Neo4j** | 7474 (HTTP), 7687 (Bolt) | Graph database for knowledge relationships |
+| **MediaWiki** | 8090 | Wiki interface for knowledge content |
+| **MariaDB** | 3306 | Database backend for MediaWiki |
+
+## Quick Start
+
+```bash
+# Start all services with interactive wiki data selection
+./start_infra.sh
+
+# Start with specific wiki directory
+./start_infra.sh --wiki-dir data/wikis_batch_top100
+
+# Skip KG indexing (faster, but no search)
+./start_infra.sh --skip-index
+
+# Force reimport even if already done
+./start_infra.sh --force
+```
+
+## Stopping Services
+
+```bash
+# Stop containers (preserves data)
+./stop_infra.sh
+
+# Stop and remove ALL data (clean slate)
+./stop_infra.sh --volumes
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    start_infra.sh                           │
+├─────────────────────────────────────────────────────────────┤
+│  1. Docker Compose Up (Weaviate, Neo4j, MediaWiki, MariaDB) │
+│  2. Wait for services to be ready                           │
+│  3. Interactive: Select wiki data directory                 │
+│  4. Import .md files to MediaWiki via API                   │
+│  5. Index wiki pages to Weaviate + Neo4j for search         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Multi-service container configuration |
+| `start_infra.sh` | Master startup + data import + indexing |
+| `stop_infra.sh` | Shutdown with optional data cleanup |
+
+## Service URLs (After Start)
+
+- **MediaWiki**: http://localhost:8090
+- **Weaviate**: http://localhost:8080/v1/meta
+- **Neo4j Browser**: http://localhost:7474 (user: `neo4j`, password: `password`)
+
+## Wiki Data
+
+The startup script prompts you to select from available wiki directories:
+- `data/wikis/` - Full wiki content
+- `data/wikis_batch_top100/` - Top 100 most important pages
+
+## Troubleshooting
+
+### Docker Permission Denied
+```bash
+sudo usermod -aG docker $USER
+# Then log out and back in
+```
+
+### Services Not Starting
+```bash
+cd services/infrastructure
+docker compose logs weaviate
+docker compose logs neo4j
+```
+
+## Environment Variables
+
+Set in `.env`:
+- `OPENAI_API_KEY` - Required for embeddings during KG indexing

--- a/services/infrastructure/docker-compose.yml
+++ b/services/infrastructure/docker-compose.yml
@@ -1,0 +1,78 @@
+# Praxium Infrastructure Stack
+# Weaviate (vector DB), Neo4j (graph DB), MediaWiki (frontend)
+
+services:
+  weaviate:
+    image: semitechnologies/weaviate:1.27.0
+    ports:
+      - "8080:8080"
+      - "50051:50051"
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      ENABLE_MODULES: 'text2vec-openai,generative-openai'
+      CLUSTER_HOSTNAME: 'node1'
+    volumes:
+      - weaviate_data:/var/lib/weaviate
+    restart: unless-stopped
+
+  neo4j:
+    image: neo4j:5.18.0
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      NEO4J_AUTH: neo4j/password
+      NEO4J_PLUGINS: '["apoc"]'
+    volumes:
+      - neo4j_data:/data
+    restart: unless-stopped
+
+  db:
+    image: mariadb:11
+    environment:
+      MYSQL_ROOT_PASSWORD: localroot123
+      MYSQL_DATABASE: wiki
+      MYSQL_USER: mediawiki
+      MYSQL_PASSWORD: localpass123
+    volumes:
+      - dbdata:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  wiki:
+    build: ../wiki_service/mediawiki
+    image: wiki-service:latest
+    environment:
+      MW_DB_HOST: db
+      MW_DB_NAME: wiki
+      MW_DB_USER: mediawiki
+      MW_DB_PASSWORD: localpass123
+      MW_SITE_SERVER: http://localhost:8090
+      MW_SITENAME: Praxium Knowledge
+      MW_LANG: en
+      MW_ADMIN_USER: admin
+      MW_ADMIN_PASS: adminpass123
+      MW_AGENT_USER: agent
+      MW_AGENT_PASS: agentpass123
+      MW_CREATE_AGENT: "true"
+    ports:
+      - "8090:80"
+    volumes:
+      - ../wiki_service/images:/var/www/html/images
+      - ../../data/wikis:/wikis:rw
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  weaviate_data:
+  neo4j_data:
+  dbdata:

--- a/services/wiki_service/tools/import_wiki_pages.py
+++ b/services/wiki_service/tools/import_wiki_pages.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+import_wiki_pages.py - Import .md wiki files into MediaWiki via API
+
+This script reads wiki pages from the data/wikis directory and imports them
+into MediaWiki using the Action API. The .md files contain MediaWiki markup.
+
+Usage:
+    # Import from default wiki directory
+    python import_wiki_pages.py
+    
+    # Import from specific directory with custom URL
+    python import_wiki_pages.py --wiki-dir data/wikis --base http://localhost:8090
+    
+    # Force reimport (overwrite existing pages)
+    python import_wiki_pages.py --force
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Add project root to path so we can import mw_client
+sys.path.insert(0, str(Path(__file__).parent))
+from mw_client import MWClient
+
+
+# Map folder names to MediaWiki namespaces
+FOLDER_TO_NAMESPACE = {
+    "heuristics": "Heuristic",
+    "workflows": "Workflow",
+    "principles": "Principle",
+    "implementations": "Implementation",
+    "environments": "Environment",
+}
+
+# Folders to skip
+SKIP_FOLDERS = {"_staging", "_reports", "_files"}
+
+
+def build_page_title(folder_name: str, filename: str) -> str:
+    """Build MediaWiki page title from folder and filename."""
+    name = filename
+    if name.endswith(".md"):
+        name = name[:-3]
+    if name.endswith(".mediawiki"):
+        name = name[:-10]
+    
+    # Replace spaces with underscores
+    name = name.replace(" ", "_")
+    
+    # Get namespace from folder
+    namespace = FOLDER_TO_NAMESPACE.get(folder_name, "")
+    
+    if namespace:
+        return f"{namespace}:{name}"
+    else:
+        return f"{folder_name}/{name}"
+
+
+def import_wikis(wiki_dir, mw, force=False, dry_run=False):
+    """Import all wiki pages from directory into MediaWiki."""
+    imported = 0
+    skipped = 0
+    failed = 0
+    
+    md_files = list(wiki_dir.rglob("*.md"))
+    print(f"Found {len(md_files)} .md files in {wiki_dir}")
+    
+    for filepath in md_files:
+        rel_path = filepath.relative_to(wiki_dir)
+        parts = rel_path.parts
+        if len(parts) < 1:
+            continue
+            
+        folder_name = parts[0]
+        
+        if folder_name in SKIP_FOLDERS or folder_name.startswith("_"):
+            continue
+        
+        page_title = build_page_title(folder_name, filepath.name)
+        
+        if "domain_tag" in page_title.lower():
+            continue
+        
+        try:
+            content = filepath.read_text(encoding="utf-8")
+        except Exception as e:
+            print(f"  ✗ Failed to read {filepath}: {e}")
+            failed += 1
+            continue
+        
+        if not content.strip():
+            skipped += 1
+            continue
+        
+        print(f"  📄 {page_title}")
+        
+        if dry_run:
+            imported += 1
+            continue
+        
+        try:
+            result = mw.edit(
+                page_title,
+                text=content,
+                summary=f"Auto-imported from {rel_path}",
+                createonly=not force,
+            )
+            
+            edit_result = result.get("edit", {}).get("result", "")
+            if edit_result == "Success":
+                imported += 1
+            else:
+                if force:
+                    result = mw.edit(page_title, text=content, summary=f"Re-imported from {rel_path}")
+                    if result.get("edit", {}).get("result") == "Success":
+                        imported += 1
+                    else:
+                        skipped += 1
+                else:
+                    skipped += 1
+                    
+        except RuntimeError as e:
+            if "articleexists" in str(e):
+                skipped += 1
+            else:
+                print(f"    ⚠ Error: {e}")
+                failed += 1
+        except Exception as e:
+            print(f"    ⚠ Error: {e}")
+            failed += 1
+    
+    return imported, skipped, failed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import wiki pages into MediaWiki")
+    parser.add_argument("--wiki-dir", type=Path, default=Path("data/wikis"))
+    parser.add_argument("--base", default=os.getenv("MW_BASE", "http://localhost:8090"))
+    parser.add_argument("--user", default=os.getenv("MW_USER", "admin"))
+    parser.add_argument("--password", default=os.getenv("MW_PASS", "adminpass123"))
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--insecure", action="store_true")
+    
+    args = parser.parse_args()
+    
+    wiki_dir = args.wiki_dir
+    if not wiki_dir.is_absolute():
+        if not wiki_dir.exists():
+            project_root = Path(__file__).parent.parent.parent.parent
+            wiki_dir = project_root / args.wiki_dir
+    
+    if not wiki_dir.exists():
+        print(f"Error: Wiki directory not found: {wiki_dir}")
+        sys.exit(1)
+    
+    print(f"{'=' * 60}")
+    print(f"MediaWiki Import")
+    print(f"Wiki directory: {wiki_dir}")
+    print(f"MediaWiki URL: {args.base}")
+    print(f"User: {args.user}")
+    print(f"Force: {args.force}, Dry run: {args.dry_run}")
+    print(f"{'=' * 60}")
+    
+    if args.dry_run:
+        print("\n[DRY RUN]\n")
+        imported, skipped, failed = import_wikis(wiki_dir, None, args.force, True)
+    else:
+        mw = MWClient(args.base, args.user, args.password, verify=not args.insecure)
+        
+        print("\nLogging into MediaWiki...")
+        try:
+            mw.login()
+            print(f"✓ Logged in (API: {mw.api_url})")
+        except Exception as e:
+            print(f"✗ Login failed: {e}")
+            sys.exit(1)
+        
+        print("\nImporting pages...")
+        imported, skipped, failed = import_wikis(wiki_dir, mw, args.force, False)
+    
+    print(f"\n{'=' * 60}")
+    print(f"✓ Imported: {imported}, ○ Skipped: {skipped}, ✗ Failed: {failed}")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/start_infra.sh
+++ b/start_infra.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# =============================================================================
+# Praxium Infrastructure Startup Script
+# - Starts Weaviate, Neo4j, MediaWiki containers
+# - Asks for wiki data directory
+# - Imports pages to MediaWiki
+# - Indexes pages for KG search
+# =============================================================================
+
+set -e
+cd "$(dirname "$0")"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+WIKI_DIR=""
+SKIP_INDEX=false
+FORCE_IMPORT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --wiki-dir)
+            WIKI_DIR="$2"
+            shift 2
+            ;;
+        --skip-index)
+            SKIP_INDEX=true
+            shift
+            ;;
+        --force)
+            FORCE_IMPORT=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --wiki-dir PATH   Wiki data directory"
+            echo "  --skip-index      Skip wiki import and indexing"
+            echo "  --force           Force reimport even if pages exist"
+            echo "  -h, --help        Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}=========================================="
+echo "  Praxium Infrastructure Startup"
+echo -e "==========================================${NC}"
+
+# Check prerequisites
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}Docker not found. Please install Docker first.${NC}"
+    exit 1
+fi
+
+# Determine if we need sudo for docker
+DOCKER_CMD="docker"
+if ! docker info &> /dev/null 2>&1; then
+    if sudo docker info &> /dev/null 2>&1; then
+        DOCKER_CMD="sudo docker"
+        echo -e "${YELLOW}Note: Using sudo for Docker commands${NC}"
+    else
+        echo -e "${RED}Docker daemon not accessible. Check permissions.${NC}"
+        exit 1
+    fi
+fi
+
+# =============================================================================
+# Step 1: Select wiki data directory (interactive if not specified)
+# =============================================================================
+if [[ -z "$WIKI_DIR" ]] && [[ "$SKIP_INDEX" == "false" ]]; then
+    echo -e "\n${YELLOW}Available wiki data directories:${NC}"
+    
+    wiki_dirs=($(ls -d data/wikis* 2>/dev/null | grep -v "_staging" | grep -v "\."))
+    
+    if [[ ${#wiki_dirs[@]} -eq 0 ]]; then
+        echo "  No wiki directories found in data/"
+        SKIP_INDEX=true
+    else
+        for i in "${!wiki_dirs[@]}"; do
+            count=$(find "${wiki_dirs[$i]}" -maxdepth 2 -name "*.md" 2>/dev/null | wc -l)
+            echo "  [$((i+1))] ${wiki_dirs[$i]} ($count .md files)"
+        done
+        echo "  [0] Skip wiki import"
+        echo ""
+        
+        if [[ -t 0 ]]; then
+            read -p "Select wiki directory [1]: " choice
+        else
+            choice=1
+        fi
+        
+        if [[ -z "$choice" ]]; then
+            choice=1
+        fi
+        
+        if [[ "$choice" == "0" ]]; then
+            SKIP_INDEX=true
+            echo "Skipping wiki import."
+        elif [[ "$choice" -ge 1 ]] && [[ "$choice" -le ${#wiki_dirs[@]} ]]; then
+            WIKI_DIR="${wiki_dirs[$((choice-1))]}"
+            echo -e "Selected: ${GREEN}$WIKI_DIR${NC}"
+        else
+            echo "Invalid choice, using default"
+            WIKI_DIR="${wiki_dirs[0]}"
+        fi
+    fi
+fi
+
+# =============================================================================
+# Step 2: Start Docker containers
+# =============================================================================
+COMPOSE_FILE="services/infrastructure/docker-compose.yml"
+
+echo -e "\n${YELLOW}Starting Docker containers...${NC}"
+echo "  - Weaviate (vector DB) on :8080"
+echo "  - Neo4j (graph DB) on :7474/:7687"  
+echo "  - MediaWiki (web UI) on :8090"
+echo "  - MariaDB (MediaWiki backend)"
+
+$DOCKER_CMD compose -f "$COMPOSE_FILE" up -d
+
+# =============================================================================
+# Step 3: Wait for services
+# =============================================================================
+echo -e "\n${YELLOW}Waiting for services...${NC}"
+
+echo -n "  Weaviate: "
+for i in $(seq 1 30); do
+    if curl -s "http://localhost:8080/v1/meta" > /dev/null 2>&1; then
+        echo -e "${GREEN}ready${NC}"
+        break
+    fi
+    if [[ $i -eq 30 ]]; then echo -e "${RED}timeout${NC}"; fi
+    echo -n "."
+    sleep 2
+done
+
+echo -n "  Neo4j: "
+for i in $(seq 1 30); do
+    if curl -s "http://localhost:7474" > /dev/null 2>&1; then
+        echo -e "${GREEN}ready${NC}"
+        break
+    fi
+    if [[ $i -eq 30 ]]; then echo -e "${RED}timeout${NC}"; fi
+    echo -n "."
+    sleep 2
+done
+
+echo -n "  MediaWiki: "
+for i in $(seq 1 30); do
+    if curl -s "http://localhost:8090/api.php" > /dev/null 2>&1; then
+        echo -e "${GREEN}ready${NC}"
+        break
+    fi
+    if [[ $i -eq 30 ]]; then echo -e "${RED}timeout${NC}"; fi
+    echo -n "."
+    sleep 2
+done
+
+# =============================================================================
+# Step 4: Import wiki pages to MediaWiki
+# =============================================================================
+if [[ "$SKIP_INDEX" == "false" ]] && [[ -n "$WIKI_DIR" ]] && [[ -d "$WIKI_DIR" ]]; then
+    echo -e "\n${YELLOW}Importing wiki pages to MediaWiki...${NC}"
+    
+    FORCE_FLAG=""
+    if [[ "$FORCE_IMPORT" == "true" ]]; then
+        FORCE_FLAG="--force"
+    fi
+    
+    if [[ -f "services/wiki_service/tools/import_wiki_pages.py" ]]; then
+        python services/wiki_service/tools/import_wiki_pages.py \
+            --wiki-dir "$WIKI_DIR" \
+            --base http://localhost:8090 \
+            $FORCE_FLAG
+    else
+        echo -e "${RED}  Import script not found!${NC}"
+    fi
+
+    # =============================================================================
+    # Step 5: Index pages for KG search (Weaviate + Neo4j)
+    # =============================================================================
+    echo -e "\n${YELLOW}Indexing pages for KG search...${NC}"
+    
+    python -c "
+from pathlib import Path
+from src.knowledge.search import KnowledgeSearchFactory, KGIndexInput
+
+print('  Connecting to Weaviate and Neo4j...')
+search = KnowledgeSearchFactory.create('kg_graph_search')
+print('  Indexing pages...')
+search.index(KGIndexInput(
+    wiki_dir=Path('$WIKI_DIR'),
+    persist_path=Path('data/indexes/wikis.json'),
+))
+search.close()
+print('  Done!')
+"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo -e "\n${GREEN}=========================================="
+echo "  Infrastructure Ready!"
+echo -e "==========================================${NC}"
+echo ""
+echo "  Services:"
+echo "    MediaWiki:  http://localhost:8090 (admin/adminpass123)"
+echo "    Neo4j:      http://localhost:7474 (neo4j/password)"
+echo "    Weaviate:   http://localhost:8080"
+echo ""
+
+if [[ "$SKIP_INDEX" == "false" ]] && [[ -n "$WIKI_DIR" ]]; then
+    page_count=$(curl -s "http://localhost:8090/api.php?action=query&meta=siteinfo&siprop=statistics&format=json" 2>/dev/null | grep -o '"pages":[0-9]*' | grep -o '[0-9]*' || echo "?")
+    echo "  Wiki Data:    $WIKI_DIR"
+    echo "  Pages:        $page_count"
+    echo ""
+fi
+
+echo "  Stop:         ./stop_infra.sh"
+echo "  Stop + wipe:  ./stop_infra.sh --volumes"

--- a/stop_infra.sh
+++ b/stop_infra.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# =============================================================================
+# Praxium Infrastructure Stop/Kill Script
+# - Stops all containers
+# - Optionally removes all data (--volumes)
+# =============================================================================
+
+cd "$(dirname "$0")"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+COMPOSE_FILE="services/infrastructure/docker-compose.yml"
+REMOVE_VOLUMES=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -v|--volumes)
+            REMOVE_VOLUMES=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -v, --volumes   Remove all volumes (wipe all data)"
+            echo "  -h, --help      Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Determine if we need sudo for docker
+DOCKER_CMD="docker"
+if ! docker info &> /dev/null 2>&1; then
+    if sudo docker info &> /dev/null 2>&1; then
+        DOCKER_CMD="sudo docker"
+    fi
+fi
+
+echo -e "${YELLOW}Stopping Praxium infrastructure...${NC}"
+
+if [[ "$REMOVE_VOLUMES" == "true" ]]; then
+    echo -e "${RED}WARNING: This will DELETE all data:${NC}"
+    echo "  - Neo4j graph database"
+    echo "  - Weaviate vector database"
+    echo "  - MediaWiki pages and database"
+    echo ""
+    
+    if [[ -t 0 ]]; then
+        read -p "Are you sure? [y/N]: " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            echo "Aborted."
+            exit 0
+        fi
+    fi
+    
+    $DOCKER_CMD compose -f "$COMPOSE_FILE" down -v --remove-orphans
+    
+    # Also clean up local index files
+    rm -f data/indexes/wikis.json 2>/dev/null
+    rm -f data/wikis/.wikis_imported 2>/dev/null
+    
+    echo -e "${GREEN}All containers and data removed.${NC}"
+else
+    $DOCKER_CMD compose -f "$COMPOSE_FILE" down
+    echo -e "${GREEN}Containers stopped. Data preserved in volumes.${NC}"
+fi
+
+echo ""
+echo "To restart: ./start_infra.sh"


### PR DESCRIPTION
## Docker Compose Stack
- Weaviate 1.27.0 (vector DB) on :8080
- Neo4j 5.18.0 (graph DB) on :7474/:7687
- MediaWiki (web UI) on :8090
- MariaDB (MediaWiki backend)

## Start Script (start_infra.sh)
- Interactive wiki data directory selection
- Automatic MediaWiki import via API
- Automatic KG indexing (Weaviate + Neo4j)
- Waits for all services to be ready
- Flags: --wiki-dir, --skip-index, --force

## Stop Script (stop_infra.sh)
- Graceful container shutdown
- Optional volume cleanup with --volumes flag

## Import Tool (import_wiki_pages.py)
- Imports .md wiki files to MediaWiki via API
- Maps folders to namespaces (Heuristic, Workflow, etc.)
- Supports --force to overwrite existing pages