### PR TITLE
feat(repo-memory): portable/auditable memory + ideation ReAct

### DIFF
--- a/developer_docs/coding_agents.md
+++ b/developer_docs/coding_agents.md
@@ -50,6 +50,9 @@ config = CodingAgentConfig(
         "timeout": 3600,              # 1 hour timeout
         "streaming": True,            # Live output to terminal
         "allowed_tools": ["Edit", "Read", "Write", "Bash"],
+        # RepoMemory section retrieval (recommended):
+        # Claude Code can call our standalone CLI via its Bash tool:
+        #   python3 tools/repo_memory_cli.py get-section core.architecture
         # For AWS Bedrock (optional):
         # "use_bedrock": True,
         # "aws_region": "us-east-1",
@@ -138,6 +141,15 @@ class CodingAgentConfig:
 ## Integration with ExperimentSession
 
 **Key Design**: `ExperimentSession` owns git operations. Agents only generate code.
+
+### RepoMemory (Summary+TOC injection + section retrieval)
+
+- **Coding prompts** inject RepoMemory **Summary + TOC** to ground implementation.
+- For **Claude Code**, we additionally support auditable section retrieval via CLI:
+  - `python3 tools/repo_memory_cli.py list-sections`
+  - `python3 tools/repo_memory_cli.py get-section core.architecture`
+
+This avoids MCP/tool wiring changes while still enabling “tool-like” access.
 
 ```python
 # ExperimentSession creates and manages coding agent

--- a/developer_docs/coding_agents_tooling_research.md
+++ b/developer_docs/coding_agents_tooling_research.md
@@ -1,0 +1,106 @@
+# Coding agent tooling research (MCP / tool calling)
+#
+# This document summarizes what our current adapters actually do today, and what
+# we would need to change to enable tool calling (MCP, CLI tools, etc.) across
+# different coding agents.
+
+## Current reality in Praxium (as implemented)
+
+### Claude Code (`claude_code`)
+
+- **Tool runtime exists** because Claude Code is a CLI agent that supports tools.
+- Our adapter already supports a tool allowlist via `--allowedTools`.
+- Today we allow only built-ins like `Edit`, `Read`, `Write`, `Bash` (see `agents.yaml`).
+- **MCP is NOT wired in the Praxium adapter today**:
+  - We do not pass an MCP config flag.
+  - Even if the user configured MCP globally, our `--allowedTools` would block
+    `mcp__...` tools unless we explicitly include them.
+
+Pragmatic short-term approach (what we implemented):
+- Provide a **RepoMemory CLI** that Claude Code can call using **Bash**:
+  - `python3 tools/repo_memory_cli.py get-section core.architecture`
+
+This gives Claude Code “tool-like” access to RepoMemory without adding MCP coupling.
+
+### Gemini (`gemini`)
+
+- Our adapter is **text-in/text-out** via Google’s SDK, then we parse code blocks.
+- Despite comments mentioning tool loops/MCP, the current adapter does **not**
+  implement:
+  - function/tool calling
+  - sandboxed execution
+  - MCP client integration
+
+If we want tools for Gemini, we need to:
+- implement function calling in the adapter and route calls to engine-defined tools
+  (e.g., “get RepoMemory section”, “grep”, “read file”, “run tests”)
+- or run Gemini as an external “agent runner” that supports tool loops.
+
+### OpenHands (`openhands`)
+
+- Our adapter is also **text-in/text-out**, plus code-block parsing.
+- It does not run the full OpenHands agent runtime (no sandbox/tools loop in this adapter).
+
+If we want OpenHands tool use, we need to:
+- integrate the actual OpenHands agent runtime (and its tool API),
+- or define an engine-mediated tool protocol similar to ideation ReAct.
+
+### Aider (`aider`)
+
+- Our adapter expects the `aider` python package (`aider.coders`) and calls `coder.run(prompt)`.
+- In this environment, Aider is often not installed, so it is unavailable unless installed.
+- Tool calling / MCP is not part of our wrapper. Aider’s “tools” are largely internal
+  to its CLI UX and would need explicit integration if we want audited tool calls.
+
+## What “real tools” would look like (future work)
+
+### Option A: Engine-mediated tools (portable, deterministic)
+
+Model outputs structured JSON actions like:
+- `{"action":"get_repo_memory_section","section_id":"core.architecture"}`
+- `{"action":"read_file","path":"src/foo.py"}`
+- `{"action":"run_tests","cmd":"pytest -q ..."}`
+
+The engine executes these actions and feeds results back into the conversation.
+
+Pros:
+- works with any LLM backend (no native tool calling required)
+- easy to log/audit centrally
+
+Cons:
+- you need to implement the protocol and loop in each adapter/flow
+
+### Option B: MCP integration (standardized, multi-tool ecosystem)
+
+Expose tools as MCP servers (like our Knowledge Search MCP server under `src/knowledge/wiki_mcps/`),
+then configure agents to connect.
+
+Pros:
+- standard protocol, works with multiple MCP clients
+- tool definitions are external and reusable
+
+Cons:
+- each agent must support MCP *and* allow tool names (e.g. `mcp__server__tool`)
+- Praxium must pass MCP config through adapters, and manage allowlists
+
+## Recommended next engineering steps
+
+1. **Claude Code MCP pass-through**
+   - Extend `ClaudeCodeCodingAgent` config to optionally pass an MCP config file path.
+   - Expand `allowed_tools` to include selected `mcp__...` tools when enabled.
+   - Keep default “safe mode” (no MCP) to avoid unexpected tool access.
+
+2. **Gemini function calling**
+   - Implement function calling in `GeminiCodingAgent` with a small set of tools:
+     - get RepoMemory section
+     - grep/read files
+     - (optionally) run tests
+
+3. **OpenHands full runtime integration**
+   - Replace the simplified litellm-based adapter with the actual OpenHands agent runtime
+     if we want sandbox + tools.
+
+4. **Aider availability + capability clarification**
+   - Make Aider adapter optional and improve error messages / install path.
+   - Decide whether we want “tool use” semantics for Aider or keep it as pure editing.
+

--- a/developer_docs/pr_repo_memory_pr_notes.md
+++ b/developer_docs/pr_repo_memory_pr_notes.md
@@ -1,0 +1,197 @@
+# PR Notes: RepoMemory V2 (evidence-backed) + Observability + Ideation ReAct
+
+This document captures **what changed** in this PR and **why**.
+It is intended to be used as PR description material and as reviewer context.
+
+## High-level goals
+
+- Make RepoMemory **portable** and **git-consistent** (no absolute paths, no ignored/transient files in RepoMap).
+- Make RepoMemory **auditable** (commit `changes.log`; persist which sections were consulted).
+- Ensure RepoMemory reflects the repo's **latest committed state** (“latest commit semantics”).
+- Externalize prompts so we can **tune them without code changes**.
+- Add **engine-mediated** “ReAct-style” section retrieval for ideation, and a CLI tool for coding-agent section access (Claude Code).
+
+## Tests run (pre-PR)
+
+- `pytest -q --collect-only`
+  - Ensures the entire repo’s test suite can be imported/collected without syntax/import errors.
+  - This is important because we touched core orchestration code and added new prompt/template files.
+
+- RepoMemory unit/integration (fast; no infra):
+  - `tests/test_repo_map_git_consistency.py`
+    - Verifies `build_repo_map()` is portable and git-consistent (e.g., filters out `.praxium/*`, `sessions/*`, and `changes.log`).
+  - `tests/test_prompt_externalization.py`
+    - Verifies all required prompt template files exist and can be loaded via `prompt_loader`.
+  - `tests/test_repo_memory_book.py`
+    - Tests RepoMemory V2 “book” APIs: Summary+TOC formatting, section retrieval, and evidence validation on book-shaped docs.
+  - `tests/test_repo_memory_book_integration.py`
+    - Integration tests for reading/migrating RepoMemory documents from worktrees and git branches.
+  - `tests/test_repo_memory_cli_standalone.py`
+    - Tests the standalone CLI (`tools/repo_memory_cli.py`) can list sections and render a section from a synthetic RepoMemory file.
+
+- LLM-gated RepoMemory tests (requires API keys; costs money):
+  - `tests/test_repo_memory.py::test_bootstrap_baseline_model_with_real_llm`
+    - Runs baseline RepoMemory inference on a seeded repo and asserts the generated memory is evidence-backed.
+  - `tests/test_repo_memory.py::test_update_after_experiment_with_real_llm`
+    - Makes real code changes, runs RepoMemory update, and asserts experiment deltas + evidence validation still pass.
+  - `tests/test_repo_memory_react_loop.py::test_ideation_react_loop_smoke`
+    - Smoke test for the engine-mediated ideation ReAct loop JSON protocol (model can request sections then return a final solution).
+  - `tests/test_repo_memory_latest_commit_semantics.py`
+    - Ensures RepoMemory updates run after final code commits (latest-commit semantics) and commit hashes line up.
+
+- RepoMemory E2E (LLM + coding agent; used to audit artifacts)
+  - `python tests/test_repo_memory_e2e.py`
+    - Runs a small seeded repo through the build loop and prints RepoMemory Book semantics + section usage for human inspection.
+    - Validates “ideation sections consulted” and `changes.log` auditability in a realistic run.
+
+- KG infra + cognitive (requires `./start_infra.sh` + indexed wiki)
+  - `python tests/test_cognitive_real_kg.py`
+    - Verifies KG connectivity and that workflow retrieval uses real KG data (no fallback).
+  - `python tests/test_expert_full_e2e.py tier1_exact_workflow`
+    - Full cognitive E2E: KG Tier 1 workflow retrieval + coding agent run + LLM judge evaluation.
+    - Includes RepoMemory audit checks (RepoMap invariants + changes.log vs persisted consulted sections).
+
+## Monitoring / test-only changes in this PR
+
+- Several changes are **test-only** or **monitoring/auditability-only** (they do not affect runtime behavior for end users):
+  - `tests/test_expert_full_e2e.py`: adds RepoMemory audit assertions (post-run invariants).
+  - `tests/test_repo_memory_e2e.py`: improves printed diagnostics so humans can judge RepoMemory quality/usage.
+  - `tests/test_claude_code_agent_bedrock.py`: makes the Bedrock smoke test opt-in and skip-by-default.
+  - `tests/deployment_examples/*`: prevents accidental pytest execution of deployment scripts; keeps deployment smoke tests opt-in.
+  - New tests under `tests/test_repo_memory_*` and `tests/test_repo_map_git_consistency.py` validate RepoMemory invariants and tooling.
+
+## Files changed vs `main`
+
+- `developer_docs/coding_agents.md`
+  - Document RepoMemory Summary+TOC injection and Claude Code section retrieval via CLI.
+
+- `src/execution/experiment_workspace/experiment_session.py`
+  - Add `schedule_repo_memory_update()` and run RepoMemory update in `close_session()` **after** final commits and **before** push/cleanup.
+  - Commit `.praxium/repo_memory.json` as the final metadata commit (latest-commit semantics).
+
+- `src/execution/experiment_workspace/experiment_workspace.py`
+  - Ensure `.gitignore` includes `!changes.log` after `*.log` so `changes.log` is committed for auditability.
+  - Pass the LLM handle into `ExperimentSession` so RepoMemory updates can run at close.
+
+- `src/execution/search_strategies/base.py`
+  - Externalize coding prompts into templates.
+  - Inject RepoMemory **Summary+TOC** (bounded) instead of a large “brief” blob.
+  - Parse `changes.log` to persist `repo_memory_sections_consulted`.
+  - Schedule RepoMemory updates instead of running them inline.
+  - Provide Claude Code instructions to use the RepoMemory CLI for section retrieval.
+
+- `src/execution/search_strategies/linear_search.py`
+  - Switch ideation to the engine-mediated RepoMemory ReAct loop and record consulted sections.
+
+- `src/execution/search_strategies/llm_tree_search.py`
+  - Switch solution generation to the engine-mediated RepoMemory ReAct loop.
+  - Record ideation-consulted section IDs on each node.
+
+- `src/expert.py`
+  - When `output_path` is provided, use it as the experiment workspace directory so the returned `solution.code_path` points to a real git repo with `.praxium/repo_memory.json`.
+
+- `src/memory/config.py`
+  - Whitespace-only formatting change.
+
+- `src/repo_memory/builders.py`
+  - RepoMap fixes:
+    - `repo_root` stored as `"."` (portable).
+    - File enumeration uses git where possible (respects `.gitignore`).
+    - Filters out `changes.log`, `.praxium/*`, `sessions/*`.
+  - Inference robustness:
+    - Reuse the same file payload during evidence-retry loops (so the model can fix its own citations).
+    - Improve evidence matching to tolerate whitespace around punctuation (handles multi-line-to-single-line quote flattening without allowing invented tokens).
+  - Planning robustness:
+    - Always include key files + entrypoints in the “files to read” selection.
+
+- `src/repo_memory/manager.py`
+  - RepoMemory updates now fall back to **full rebuild with retry feedback** on evidence failure.
+  - Comments updated to consistently refer to “RepoMemory V2” format.
+
+- `tests/deployment_examples/input_repos/chatbot_adapted_langgraph/test_deployment.py`
+  - Fix indentation so pytest can import/collect the file.
+  - Still skip-by-default unless `PRAXIUM_RUN_DEPLOYMENT_TESTS=1`.
+  - **Why in this PR**: on `main`, this file was an ad-hoc script under `tests/` that performed HTTP calls at import time.
+    That is unsafe for pytest collection and can hang/fail CI. We converted it into an opt-in smoke test.
+
+- `tests/deployment_examples/test_unified_deployment.py`
+  - Rename `test_repo()` -> `run_repo()` to avoid accidental pytest collection.
+  - Keep it as a script-style deployment runner.
+  - **Why in this PR**: on `main`, the helper was named `test_repo()`, so pytest could treat it as a real test even though
+    it depends on external deployment/runtime setup. Renaming makes it opt-in (script-run), not an accidental test gate.
+
+- `tests/test_claude_code_agent_bedrock.py`
+  - Make the Bedrock smoke test skip-by-default unless explicitly enabled (`PRAXIUM_RUN_BEDROCK_TESTS=1`) and credentials + `claude` CLI exist.
+
+- `tests/test_expert_flow.py`
+  - Whitespace-only formatting change.
+
+- `tests/test_expert_full_e2e.py`
+  - Add post-run RepoMemory audit checks:
+    - RepoMap invariants (portable + excludes meta paths)
+    - `changes.log` auditability and consistency with persisted `repo_memory_sections_consulted`
+
+- `tests/test_repo_memory.py`
+  - Adjust tests for the updated RepoMemory behavior (prompt externalization + evidence robustness).
+
+- `tests/test_repo_memory_e2e.py`
+  - Improve printed diagnostics:
+    - show semantic claim statements
+    - show ideation sections consulted
+    - show coding-agent sections consulted
+
+## New files added
+
+- `developer_docs/coding_agents_tooling_research.md`
+  - Research notes on coding agent tooling capabilities and next steps.
+
+- `developer_docs/prompt_tuning.md`
+  - How to tune externalized templates (including override via env var).
+
+- `developer_docs/pr_repo_memory_pr_notes.md`
+  - This PR-notes file.
+
+- `paper/Praxium_paper_v1.md`, `paper/Praxium_paper_v1.tex`
+  - Draft paper artifacts (documentation/research; no runtime impact).
+
+- `src/core/prompt_loader.py`
+  - Prompt template loader + simple renderer, with optional override directory.
+
+- `src/execution/ideation/repo_memory_react.py` (+ `src/execution/ideation/__init__.py`)
+  - Engine-mediated ReAct loop for ideation: model can request RepoMemory sections by ID before outputting a final solution.
+
+- `src/execution/prompts/`
+  - `coding_agent_implement.md`, `coding_agent_debug.md`, `ideation_solution_react.md`
+  - Externalized templates for coding-agent prompting and ideation ReAct protocol.
+
+- `src/repo_memory/cli.py`
+  - RepoMemory CLI that imports `RepoMemoryManager` but keeps stdout clean (redirects import noise).
+
+- `src/repo_memory/observation.py`
+  - Observability helpers (extract consulted sections from `changes.log`, book stats).
+
+- `src/repo_memory/prompts/`
+  - `plan_files_to_read.md`, `infer_repo_model_initial.md`, `infer_repo_model_retry.md`, `infer_repo_model_update.md`
+  - Externalized prompts for RepoMemory inference and update.
+
+- `tests/test_prompt_externalization.py`
+  - Confirms prompt template files exist and are loadable.
+
+- `tests/test_repo_map_git_consistency.py`
+  - Guards RepoMap portability and filtering of meta paths.
+
+- `tests/test_repo_memory_book.py`, `tests/test_repo_memory_book_integration.py`
+  - Tests around RepoMemory V2 “book” rendering, section access, and migration behavior.
+
+- `tests/test_repo_memory_cli_standalone.py`
+  - Tests the standalone CLI in `tools/`.
+
+- `tests/test_repo_memory_latest_commit_semantics.py`
+  - Ensures RepoMemory update commit timing matches “latest commit semantics”.
+
+- `tests/test_repo_memory_react_loop.py`
+  - Tests JSON protocol parsing and includes a smoke run of ideation ReAct.
+
+- `tools/repo_memory_cli.py`
+  - Standalone CLI for agents (no `import src`) that reads `.praxium/repo_memory.json` directly.
+

--- a/developer_docs/prompt_tuning.md
+++ b/developer_docs/prompt_tuning.md
@@ -1,0 +1,53 @@
+# Prompt Tuning (externalized templates)
+#
+# This project externalizes large prompt strings into files so they can be tuned
+# without touching python logic. This is critical for RepoMemory quality and for
+# agent prompt iteration.
+
+## Where prompts live
+
+### RepoMemory builders
+
+- `src/repo_memory/prompts/plan_files_to_read.md`
+- `src/repo_memory/prompts/infer_repo_model_initial.md`
+- `src/repo_memory/prompts/infer_repo_model_retry.md`
+- `src/repo_memory/prompts/infer_repo_model_update.md`
+
+### Execution prompts (agents + ideation)
+
+- `src/execution/prompts/coding_agent_implement.md`
+- `src/execution/prompts/coding_agent_debug.md`
+- `src/execution/prompts/ideation_solution_react.md`
+
+## How prompts are loaded
+
+All prompt loading is centralized in:
+
+- `src/core/prompt_loader.py`
+
+It provides:
+
+- `load_prompt("execution/prompts/coding_agent_implement.md")`
+- `render_prompt(template, {"var": "value"})` using `{{var}}` placeholders
+
+## Override prompts without changing code
+
+Set an environment variable:
+
+```bash
+export PRAXIUM_PROMPTS_DIR=/path/to/your/prompts_root
+```
+
+Then a call like:
+
+```python
+load_prompt("execution/prompts/coding_agent_implement.md")
+```
+
+will read from:
+
+`/path/to/your/prompts_root/execution/prompts/coding_agent_implement.md`
+
+This is useful when you want to tune prompts in a separate directory (e.g., mounted
+volume or a different git branch) while keeping the engine code unchanged.
+

--- a/paper/Praxium_paper_v1.md
+++ b/paper/Praxium_paper_v1.md
@@ -1,0 +1,422 @@
+**Praxium: A Knowledge-Grounded AI Framework for Iterative Experiment-Driven Software Synthesis and Optimization**
+
+**Authors**: _[TODO: add authors and affiliations]_
+
+**Date**: 2026-01-02
+
+---
+
+### Abstract
+
+We introduce **Praxium**, a modular framework that converts a natural-language goal into runnable software through an iterative loop of **proposal**, **implementation**, **execution**, and **evaluation**. Praxium targets long-horizon failures common in coding agents—lost experimental state, brittle debugging, and weak reuse of domain expertise—by integrating three tightly coupled components. First, a **git-native experimentation engine** isolates each attempt as a branch, producing reproducible artifacts and preserving provenance across iterations. Second, a **knowledge system** ingests heterogeneous sources—including repositories, benchmark artifacts (starter code and evaluation scripts), internal playbooks, and curated external resources such as documentation, scientific papers, and web search results—and organizes them into a structured representation that supports hybrid retrieval over workflows, implementations, and environment constraints. This knowledge can be provided via offline ingestion and, when enabled, via tool-based web search during builds, with retrieval provenance recorded. Third, a **cognitive memory layer** performs **tiered retrieval** and maintains an **episodic store** of reusable lessons distilled from prior experiment traces (run logs, diffs, and evaluator feedback), enabling the system to reduce repeated error modes and accelerate convergence. We evaluate Praxium on **MLE-Bench** (Kaggle-style ML competitions) and **ALE-Bench** (AtCoder heuristic optimization), which stress ML engineering under long runtimes and algorithmic optimization under strict time limits, respectively, and report end-to-end performance, cost, and ablations of the search, knowledge, and memory components.
+
+---
+
+### 1. Introduction
+
+Domain experts often know what they want to build, but turning that intent into reliable, runnable software still requires repeated experimentation. In practice, successful development is an iterative process: propose an approach, implement it, run it in the real environment, inspect outcomes, and refine. This loop is especially visible in Data and AI programs, where progress depends on many measurable improvements and on careful management of code, data, and evaluation contracts. Importantly, iterations often succeed in the narrow sense of producing a working artifact, yet still fall short on quality, accuracy, robustness, or efficiency. Practical progress therefore requires repeated evaluation and targeted improvement, not only error fixing.
+
+LLM-based coding agents reduce the cost of writing code, but they remain unreliable in long-horizon execution loops. Common failure modes include losing state across iterations, repeatedly triggering the same integration errors, and failing to reuse relevant engineering expertise even when it is available in repositories, documentation, internal playbooks, or prior attempts. In many real settings, the decisive advantage is not raw code generation, but the ability to consistently apply expert-grade best practices and high-leverage engineering workflows, including environment setup, data contracts, evaluation harnessing, debugging procedures, and performance tuning. A second practical limitation is reproducibility. Without explicit experiment isolation and provenance, it is difficult to compare approaches, debug regressions, or reuse successful solutions as building blocks.
+
+We present **Praxium**, a framework that turns knowledge into executable software through an execution-grounded loop of iterative improvement. Given a natural-language goal and an evaluation interface, Praxium repeatedly generates candidate solution specifications, applies code changes, executes the resulting artifact under a task-defined evaluator, and uses measured outcomes to guide subsequent iterations. The system integrates three tightly coupled components. First, a **git-native experimentation engine** isolates each attempt as a branch, capturing code changes, logs, and evaluation outputs as reproducible artifacts. Second, a **knowledge system** ingests heterogeneous sources, including repositories, benchmark artifacts, internal playbooks, documentation, scientific papers, and web-derived material, and organizes them into a structured representation that supports retrieval of workflows, implementations, heuristics, and environment constraints. This knowledge is hosted in **MediaWiki**, providing a familiar interface for human review, curation, and human-in-the-loop iteration. We release a complete knowledge package consisting of a MediaWiki dump, Neo4j and Weaviate snapshots, and Docker-based deployment scripts that bring up the MediaWiki instance and all indices in a reproducible configuration. Third, a **cognitive memory layer** performs tiered retrieval and maintains an episodic store of reusable lessons distilled from experiment traces, such as run logs, diffs, and evaluator feedback, to reduce repeated error modes and accelerate convergence.
+
+Praxium is intentionally modular. It supports pluggable evaluators, knowledge backends, and coding agents, enabling the same iteration loop to be applied across domains where progress is defined by executable outcomes and measurable objectives. We instantiate this design and evaluate it on two complementary benchmarks, MLE-Bench and ALE-Bench, and we use these instantiations to study end-to-end performance, cost, and ablations of the search, knowledge, and memory components. Beyond these benchmarks, the same interfaces generalize to additional tasks by swapping the evaluator and the knowledge sources.
+
+#### Contributions
+
+This paper makes the following contributions:
+
+1. An end-to-end framework that converts heterogeneous knowledge into executable software via evaluator-grounded experimentation and iterative improvement.
+2. A git-native experimentation engine that represents each attempt as an isolated, reproducible branch with explicit provenance.
+3. A knowledge acquisition and representation pipeline hosted in MediaWiki that converts heterogeneous sources into a typed, workflow-oriented knowledge base usable at runtime.
+4. A cognitive memory system that combines tiered retrieval with episodic learning from experiment traces to reduce repeated failures and accelerate iteration.
+5. A modular architecture with pluggable evaluators and knowledge sources, demonstrated through benchmark instantiations and ablations, together with a released knowledge package containing a MediaWiki dump, Neo4j and Weaviate snapshots, and Docker-based deployment scripts for reproducing the full stack. The released knowledge base is populated from over 2,000 widely used Data and ML repositories, with selection criteria defined later.
+
+---
+
+### 2. Framework Overview
+
+At a high level, Praxium exposes a user-facing `Expert` API:
+
+- **learn**: ingest knowledge sources (e.g., repos) into the knowledge system.
+- **build**: run an experiment loop to produce a working solution.
+- **deploy**: adapt a solution to a target deployment strategy and return a unified runtime interface.
+
+Internally, the build process is orchestrated by an `OrchestratorAgent` that composes four pluggable subsystems:
+
+- **SearchStrategy**: how we generate and select candidate solutions (e.g., LLM-steered tree search).
+- **ContextManager**: what context we pass into solution generation and implementation (legacy vs. cognitive).
+- **KnowledgeSearch**: how we retrieve domain knowledge at runtime (legacy LLM-navigation vs. hybrid KG search).
+- **CodingAgent**: which code generator applies edits (e.g., Aider, Claude Code, Gemini).
+
+This modular design is intentional. It allows Praxium to swap out components without changing the solve loop or the benchmark harnesses.
+
+---
+
+### 3. Formalization (Notation and Algorithms)
+
+This section introduces notation and formal operators for the full Praxium framework. The goal is to make the system comparable to prior work in program synthesis, agentic search, and black-box optimization by stating (i) the objects Praxium manipulates, (ii) the objective it optimizes, and (iii) the algorithms it runs.
+
+#### 3.1 Task model and objective
+
+We model each benchmark instance as a **task** \(t \in \mathcal{T}\) with a black-box execution-and-scoring interface. In the codebase, this is implemented by a `ProblemHandler` (and optionally an `Evaluator`), but for formalization we treat it as an environment:
+
+- **Goal / objective**: \(g\) is a natural-language goal (optionally with constraints). Praxium may also represent this as a structured `Objective` / `Goal`.
+- **Budget progress**: \(\beta_i \in [0,1]\) is the normalized progress fraction at iteration \(i\) (derived from time / iteration / cost budgets).
+- **Problem context**: \(P_t(\beta)\) returns the task description string shown to the agent at a given budget progress (budget-aware in MLE).
+- **Execution + scoring**: \(\mathrm{Run}_t(c)\) executes a code artifact \(c\) (a repository state in an experiment branch) and returns a result tuple
+
+\[
+r = (\text{had\_error},\; y,\; o,\; m,\; f)
+\]
+
+where \(y \in \mathbb{R}\) is the score, \(o\) is runtime output, \(m\) is an error message/details (if any), and \(f\) is optional evaluator feedback.
+
+Many benchmarks define either a maximize or minimize objective. We normalize this with a sign \(s_t \in \{+1,-1\}\) and define the **normalized utility**:
+
+\[
+J_t(c) = s_t \cdot y_t(c)
+\]
+
+so Praxium can always be described as maximizing \(J_t\).
+
+Finally, we define an **experiment history** after iteration \(i\) as:
+
+\[
+H_i = \{e_1,\dots,e_{i-1}\},\quad e_j = (b_j,\; u_j,\; y_j,\; \text{had\_error}_j,\; m_j,\; f_j)
+\]
+
+where \(b_j\) is the branch identifier and \(u_j\) is the natural-language solution specification used to generate code for that branch.
+
+#### 3.2 Knowledge grounding as retrieval operators
+
+Let \(\mathcal{G}=(\mathcal{V},\mathcal{E})\) be a typed knowledge graph where each page/node \(v \in \mathcal{V}\) has:
+
+- an ID and title,
+- a type in \(\{\text{Workflow},\text{Principle},\text{Implementation},\text{Environment},\text{Heuristic}\}\),
+- overview/content text (and sometimes code snippets),
+- typed edges in \(\mathcal{E}\) (e.g., `STEP`, `IMPLEMENTED_BY`, `USES_HEURISTIC`, `REQUIRES_ENV`).
+
+Praxium uses a retrieval backend that supports at least:
+
+- \(\mathrm{Search}(q, F)\rightarrow \langle (v_k,\mathrm{score}_k)\rangle\): semantic/graph search for a query \(q\) under filters \(F\),
+- \(\mathrm{GetPage}(id)\rightarrow v\): fetch full content for a page by ID/title,
+- optional graph traversal \(\mathrm{Traverse}(v)\) to collect linked knowledge.
+
+The output of retrieval is a **knowledge packet** \(K\) (implemented as `KGKnowledge`) containing:
+
+- tier label (Tier 1 / 2 / 3),
+- confidence (retrieval score),
+- provenance metadata (`query_used`, `source_pages`),
+- structured workflow (if any), otherwise a list of relevant principles,
+- optional error-recovery attachments (heuristics + alternative implementations).
+
+#### 3.3 Core solve loop (Orchestrator)
+
+At the top level, Praxium repeatedly builds context and executes experiments until a stop condition fires. In the codebase this is `OrchestratorAgent.solve()` plus a chosen `SearchStrategy`.
+
+```text
+Algorithm 1: Praxium solve loop (orchestrator-level)
+Inputs:
+  - task handler H_t (problem context + run + stop)
+  - search strategy S (linear or tree)
+  - context manager M (legacy or cognitive)
+  - budgets (iterations/time/cost)
+
+Initialize i = 0
+while i < N:
+  β_i = budget_progress(time, i, cost)
+  if Stop_t(β_i) or β_i >= 1: break
+
+  x_i = M.get_context(β_i)         # includes P_t(β_i), knowledge, and history
+  if M.should_stop(): break        # only meaningful for cognitive mode
+
+  S.run(x_i, β_i)                  # executes ≥1 experiments and updates its history
+  i = i + 1
+
+return best experiment in S.history (maximizing J_t)
+```
+
+This formalization makes explicit that Praxium is a **search over code artifacts** driven by repeated experiments and task-defined scoring.
+
+#### 3.4 Implement-and-debug loop (SearchStrategy)
+
+Both linear and tree search ultimately execute the same inner loop: create an isolated branch, implement a solution, run it, and optionally debug it for a bounded number of tries. In the codebase this is `SearchStrategy._implement_n_debug()`.
+
+```text
+Algorithm 2: Implement-and-debug loop (branch-level)
+Inputs:
+  - solution spec u
+  - context x (problem + knowledge + history)
+  - debug budget D
+  - branch name b and parent branch p
+
+session = create_experiment_session(branch=b, parent=p)
+r = implement_solution(u, x, session)          # codegen + Run_t
+
+for k in 1..D:
+  if r.had_error and r.continue_debugging:
+    r = debug_solution(u, x, r.error_details, session)
+  else:
+    break
+
+finalize_session(session)                      # commits + push + cleanup
+return r
+```
+
+#### 3.5 LLM-steered tree search (one concrete instantiation)
+
+For completeness, we formalize the LLM-steered tree search used in MLE/ALE configurations. Let \(T=(\mathcal{N},\mathcal{A})\) be a tree of nodes \(\mathcal{N}\), where each node stores a solution spec \(u(n)\) and an optional experiment result \(e(n)\).
+
+At each outer iteration, the strategy:
+
+- \(\mathrm{Prune}\): optionally terminates some leaf nodes using an LLM conditioned on \((P_t(\beta_i),K_i,H_i)\).
+- \(\mathrm{Expand}\): chooses nodes to expand (exploration vs. exploitation) and generates new child solution specs via an LLM ensemble.
+- \(\mathrm{Select}\): selects top-\(k\) leaf nodes to execute as experiments (again using an LLM conditioned on context).
+
+This can be viewed as a learned proposal distribution over solution specs \(u\), combined with black-box evaluation through \(\mathrm{Run}_t(\cdot)\).
+
+#### 3.6 Cognitive memory (tiered retrieval + episodic learning + decisions)
+
+When the cognitive context manager is enabled, Praxium augments the loop with a controller state \(C_i\) containing:
+
+- the goal \(g\),
+- knowledge packet \(K_i\),
+- last experiment result \(e_{i-1}\),
+- episodic insights \(Z_i\),
+- meta statistics (e.g., consecutive failures).
+
+The controller defines:
+
+- \(\mathrm{TieredRetrieve}(g, e_{i-1})\rightarrow K_i\): Tier 1/2 retrieval, plus Tier 3 augmentation after failures,
+- \(\mathrm{UpdateEpisodic}(e_{i-1})\rightarrow E\): store generalized lessons from errors/successes,
+- \(\pi(C_i)\in\{\textsc{Retry},\textsc{Pivot},\textsc{Complete}\}\): an LLM policy over iteration-level actions.
+
+```text
+Algorithm 3: Cognitive controller step (per experiment)
+Inputs: goal g, current knowledge K, episodic store E, last result e
+
+if e.had_error:
+  E.add(ExtractError(g, e.error_message))
+  K = Tier3(g, e.error_message, K)                 # add error heuristics + alternatives
+else if e.feedback is non-empty:
+  E.add(ExtractSuccess(g, e.feedback))
+
+Z = RetrieveEpisodic(E, g, e.error_message, e.feedback)
+a = DecideAction(g, K, e, Z)                        # RETRY / PIVOT / COMPLETE
+
+if a == PIVOT:
+  K = TieredRetrieve(g, exclude_current_workflow=True)
+
+return (a, K, Z)
+```
+
+The key property is that both the coding agent and the decision maker are grounded in the same rendered context, and Tier 3 explicitly records provenance via `query_used` and `source_pages`.
+
+---
+
+### 4. Experimentation Engine
+
+#### 4.1 Git-native experiment isolation
+
+Praxium models each experiment as a **git branch**. Concretely, an `ExperimentWorkspace` initializes a git repo and creates isolated `ExperimentSession`s. Each session:
+
+- clones the workspace,
+- checks out a parent branch (to inherit code),
+- creates a new experiment branch,
+- calls a configured coding agent to implement the candidate solution,
+- runs the benchmark handler, and
+- commits outputs and pushes the branch for reproducibility and downstream reuse.
+
+This makes experiments debuggable. It also enables tree search over solutions without losing provenance.
+
+#### 4.2 Search strategies
+
+Praxium includes two search strategies:
+
+- **Linear search**: generate a single solution per iteration and refine based on history.
+- **LLM-steered tree search**: maintain a tree of solution candidates, expand nodes with new ideas, prune unpromising leaves, and run selected leaves in parallel.
+
+The tree search has three LLM-mediated decisions:
+
+- **Generation**: propose diverse candidate solutions.
+- **Selection**: pick which nodes to run next based on expected improvement and diversity.
+- **Pruning**: remove leaves that appear unlikely to improve given history and knowledge.
+
+This design is practical. It allows fast exploration early and exploitation later, while staying compatible with strict evaluation loops (e.g., ALE’s fixed iteration budget).
+
+---
+
+### 5. Knowledge System
+
+Praxium’s knowledge system is designed to turn unstructured codebases into structured, searchable expertise that can be reused during builds.
+
+#### 5.1 Knowledge acquisition: Repo → typed wiki pages
+
+The `KnowledgePipeline` coordinates a two-stage flow:
+
+- **Stage 1 (Ingestors)**: parse a source (primarily a git repo) into a set of `WikiPage`s.
+- **Stage 2 (Merger)**: merge the proposed pages into the main KG (create new pages or merge into existing ones).
+
+For repositories, `RepoIngestor` runs a two-branch, multi-phase pipeline:
+
+- **Branch 1 (workflow-based extraction)**: find workflows from READMEs and examples; then trace code paths to write paired Principle+Implementation pages; then extract environments and heuristics; finally run an audit step.
+- **Branch 2 (orphan mining)**: identify useful files not reached by workflow tracing, triage them deterministically, ask an agent to review ambiguous cases, create pages for approved orphans, and verify coverage.
+
+This design reduces “knowledge holes” that arise when only top-down workflows are extracted.
+
+#### 5.2 Knowledge representation: a typed wiki schema
+
+Praxium uses a typed schema with five page types:
+
+- **Workflow**: an ordered recipe (steps).
+- **Principle**: theory-level concept.
+- **Implementation**: concrete API / code reference (often includes code snippets).
+- **Environment**: dependencies and system constraints.
+- **Heuristic**: tips and optimizations.
+
+The schema is a directed structure (Workflow → Principle → Implementation) with heuristics attachable at multiple levels and environment requirements attached to implementations. This structure matters because it bounds context and makes retrieval compositional.
+
+#### 5.3 Runtime retrieval backends
+
+Praxium ships two knowledge-search backends:
+
+- **Legacy: KG LLM Navigation (`kg_llm_navigation`)**  
+  Stores a graph in Neo4j and uses an LLM to navigate neighbor nodes for a query. This backend can be seeded from a compact JSON graph (e.g., `benchmarks/mle/data/kg_data.json`).
+
+- **Hybrid: KG Graph Search (`kg_graph_search`)**  
+  Uses Weaviate embeddings for semantic retrieval and Neo4j for graph enrichment. It optionally applies LLM reranking. This backend is designed for typed wiki pages and supports richer workflow traversal.
+
+These backends allow a continuum: fast legacy graph navigation for lightweight setups vs. hybrid semantic+graph retrieval when a full wiki KG is available.
+
+---
+
+### 6. Cognitive Memory System (Optional, Workflow-Aware)
+
+Praxium includes an opt-in cognitive memory layer implemented as a context manager (`context_manager: cognitive`). This subsystem is designed to eliminate sharp edges in long-horizon solving: lost feedback, opaque fallbacks, and untraceable retrieval behavior.
+
+#### 6.1 Tiered knowledge retrieval
+
+The cognitive controller retrieves knowledge in three tiers:
+
+- **Tier 1 (exact workflow)**: find a matching workflow via semantic search, then traverse the workflow’s ordered steps to collect linked principles, implementations, heuristics, and environments.
+- **Tier 2 (relevant principles)**: if no workflow match exists, return relevant principles and their linked implementations/heuristics (without fabricating a workflow).
+- **Tier 3 (error recovery)**: after a failure, generate error-targeted queries, retrieve error-specific heuristics and alternative implementations, and add them to the existing knowledge packet.
+
+Critically, Tier 3 records provenance: it appends the exact error queries into a `query_used` field and adds the retrieved source page IDs into `source_pages`. This supports auditability and reproducibility.
+
+#### 6.2 Episodic memory: learning from experiments
+
+In addition to KG retrieval, the cognitive controller maintains an episodic store of reusable insights. After each experiment:
+
+- on **failure**, an LLM generalizes the error into a reusable lesson with trigger conditions and suggested fixes;
+- on **success**, an LLM extracts best-practice insights from evaluator feedback.
+
+These insights are stored in a vector database (Weaviate) with a JSON fallback. On subsequent iterations, an LLM generates an episodic retrieval query conditioned on the current goal and the most recent error/feedback, then ranks candidate insights for applicability.
+
+#### 6.3 LLM-based decision making
+
+After each experiment, the controller asks an LLM to decide one of:
+
+- **RETRY**: try again with the current knowledge/workflow,
+- **PIVOT**: re-retrieve knowledge while excluding the current workflow, or
+- **COMPLETE**: stop early because the goal is achieved.
+
+The decision is grounded in the same unified context blob that is sent to the coding agent (goal, knowledge packet, last experiment state, and episodic insights). This keeps decisions interpretable.
+
+---
+
+### 7. Evaluation
+
+We evaluate Praxium on two benchmarks that capture distinct real-world software-building regimes.
+
+#### 7.1 MLE-Bench (Kaggle-style ML competitions)
+
+**Task**: produce a Python solution that trains on provided competition data and writes a `final_submission.csv` in the expected format.
+
+**Execution protocol** (as implemented in the benchmark handler):
+
+- run **debug mode** first (`python main.py --debug`) with a strict runtime cap,
+- validate the submission file format,
+- run **full mode** (`python main.py`) with a longer runtime budget,
+- grade the output submission on the competition’s hidden/private split.
+
+**Stop condition**: stop early if the run achieves **any medal** according to the MLE-Bench grading library.
+
+**Reported metrics**:
+
+- **Private score**: returned by the benchmark grader.
+- **Medal rate**: fraction of competitions where any medal is achieved.
+- **Cost**: cumulative LLM usage cost tracked by the framework.
+
+**Results**: _[TODO: insert your MLE-Bench results table: competitions, private scores, medals, cost]_.
+
+#### 7.2 ALE-Bench (AtCoder heuristic contests)
+
+**Task**: produce a C++ (`cpp23`) solution in `main.cpp` to maximize/minimize a contest-defined score under a strict per-run time limit.
+
+**Execution protocol**:
+
+- compile and run in the benchmark’s Docker environment,
+- if the solution is accepted, run it multiple times and average the score to reduce variance,
+- evaluate on a private test set to obtain final rank.
+
+**Reported metrics**:
+
+- **Final rank** on the private evaluation.
+- **Rank percentile**: final_rank / number_of_contestants.
+- **Private absolute score** (contest objective value).
+- **Cost**: cumulative LLM usage cost.
+
+**Results**: _[TODO: insert your ALE-Bench results table: problems, rank, percentile, score, cost]_.
+
+---
+
+### 8. Discussion
+
+#### 8.1 Why MLE-Bench and ALE-Bench are complementary
+
+MLE-Bench stresses data engineering, model training, file I/O contracts, and long runtimes. ALE-Bench stresses algorithmic design, tight time limits, and stochastic optimization. Together they expose different “sharp edges” in agent frameworks: brittle file outputs, poor runtime reasoning, lack of iterative improvement, and inability to reuse domain knowledge.
+
+#### 8.2 What we expect memory to change
+
+In Praxium, memory is not a monolith. The system supports:
+
+- **short-horizon memory** (recent/top experiment summaries),
+- **domain memory** (KG retrieval), and
+- **self-memory** (episodic insights from past experiments).
+
+We expect the cognitive memory layer to reduce repeated failure modes and shorten time-to-success on tasks with recurring errors (dependency issues, common API misuse, evaluation contract errors). We also expect provenance tracking to make benchmark runs auditable.
+
+---
+
+### 9. Limitations
+
+- **External services**: the full KG graph search relies on Neo4j + Weaviate and may require infrastructure setup.
+- **LLM dependence**: performance depends on the underlying LLMs used for idea generation, coding, reranking, and decisions.
+- **Benchmark mismatch**: some real-world constraints (security policies, proprietary APIs, long-term maintenance) are not captured by MLE/ALE.
+
+---
+
+### 10. Conclusion
+
+Praxium is a framework for building software by running experiments, using structured knowledge, and optionally learning from experience. Its core contributions are a git-native experimentation engine, a scalable knowledge acquisition and retrieval system, and a workflow-aware cognitive memory layer with tiered retrieval and episodic learning. The framework is designed to be modular and auditable. We recommend reporting benchmark results with both performance and cost, and we provide a clear execution protocol for MLE-Bench and ALE-Bench to enable reproducible evaluation.
+
+---
+
+### Appendix A. Reproducibility checklist
+
+- **Configuration**: record the exact mode configs (search strategy params, coding agent model, knowledge search backend).
+- **KG snapshot**: record the wiki snapshot / KG index version used for the run.
+- **LLM versions**: record exact model strings (including provider prefixes) for all LLM calls.
+- **Randomness**: record MLE seed and ALE run counts.
+
+---
+
+### Appendix B. Suggested tables to include in v1
+
+- **Table 1**: MLE-Bench results per competition (private score, medal, cost, iterations).
+- **Table 2**: ALE-Bench results per problem (rank, percentile, private score, cost, iterations).
+- **Table 3**: Ablation: KG on/off; cognitive context manager on/off.
+
+

--- a/paper/Praxium_paper_v1.tex
+++ b/paper/Praxium_paper_v1.tex
@@ -1,0 +1,472 @@
+% Praxium paper (v1)
+%
+% This .tex file is a LaTeX rendering of `paper/Praxium_paper_v1.md`.
+% It intentionally avoids unicode punctuation (e.g., “ ”, →) so it compiles
+% cleanly under pdflatex without extra configuration.
+%
+% Compile (example):
+%   pdflatex -interaction=nonstopmode -halt-on-error paper/Praxium_paper_v1.tex
+%
+\documentclass[11pt]{article}
+
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc} % Needed for older pdflatex; harmless on modern LaTeX.
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage{geometry}
+\geometry{margin=1in}
+\usepackage{enumitem}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{hyperref}
+
+\title{Praxium: A Knowledge-Grounded AI Framework for Iterative Experiment-Driven Software Synthesis and Optimization}
+\author{[TODO: add authors and affiliations]}
+\date{2026-01-02}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+We introduce \textbf{Praxium}, a modular framework that converts a natural-language goal into runnable software through an iterative loop of \textbf{proposal}, \textbf{implementation}, \textbf{execution}, and \textbf{evaluation}. Praxium targets long-horizon failures common in coding agents--lost experimental state, brittle debugging, and weak reuse of domain expertise--by integrating three tightly coupled components. First, a \textbf{git-native experimentation engine} isolates each attempt as a branch, producing reproducible artifacts and preserving provenance across iterations. Second, a \textbf{knowledge system} ingests heterogeneous sources--including repositories, benchmark artifacts (starter code and evaluation scripts), internal playbooks, and curated external resources such as documentation, scientific papers, and web search results--and organizes them into a structured representation that supports hybrid retrieval over workflows, implementations, and environment constraints. This knowledge can be provided via offline ingestion and, when enabled, via tool-based web search during builds, with retrieval provenance recorded. Third, a \textbf{cognitive memory layer} performs \textbf{tiered retrieval} and maintains an \textbf{episodic store} of reusable lessons distilled from prior experiment traces (run logs, diffs, and evaluator feedback), enabling the system to reduce repeated error modes and accelerate convergence. We evaluate Praxium on \textbf{MLE-Bench} (Kaggle-style ML competitions) and \textbf{ALE-Bench} (AtCoder heuristic optimization), which stress ML engineering under long runtimes and algorithmic optimization under strict time limits, respectively, and report end-to-end performance, cost, and ablations of the search, knowledge, and memory components.
+\end{abstract}
+
+\section{Introduction}
+
+Domain experts often know what they want to build, but turning that intent into reliable, runnable software still requires repeated experimentation. In practice, successful development is an iterative process: propose an approach, implement it, run it in the real environment, inspect outcomes, and refine. This loop is especially visible in Data and AI programs, where progress depends on many measurable improvements and on careful management of code, data, and evaluation contracts. Importantly, iterations often succeed in the narrow sense of producing a working artifact, yet still fall short on quality, accuracy, robustness, or efficiency. Practical progress therefore requires repeated evaluation and targeted improvement, not only error fixing.
+
+LLM-based coding agents reduce the cost of writing code, but they remain unreliable in long-horizon execution loops. Common failure modes include losing state across iterations, repeatedly triggering the same integration errors, and failing to reuse relevant engineering expertise even when it is available in repositories, documentation, internal playbooks, or prior attempts. In many real settings, the decisive advantage is not raw code generation, but the ability to consistently apply expert-grade best practices and high-leverage engineering workflows, including environment setup, data contracts, evaluation harnessing, debugging procedures, and performance tuning. A second practical limitation is reproducibility. Without explicit experiment isolation and provenance, it is difficult to compare approaches, debug regressions, or reuse successful solutions as building blocks.
+
+We present \textbf{Praxium}, a framework that turns knowledge into executable software through an execution-grounded loop of iterative improvement. Given a natural-language goal and an evaluation interface, Praxium repeatedly generates candidate solution specifications, applies code changes, executes the resulting artifact under a task-defined evaluator, and uses measured outcomes to guide subsequent iterations. The system integrates three tightly coupled components. First, a git-native experimentation engine isolates each attempt as a branch, capturing code changes, logs, and evaluation outputs as reproducible artifacts. Second, a knowledge system ingests heterogeneous sources, including repositories, benchmark artifacts, internal playbooks, documentation, scientific papers, and web-derived material, and organizes them into a structured representation that supports retrieval of workflows, implementations, heuristics, and environment constraints. This knowledge is hosted in \textbf{MediaWiki}, providing a familiar interface for human review, curation, and human-in-the-loop iteration. We release a complete knowledge package consisting of a MediaWiki dump, Neo4j and Weaviate snapshots, and Docker-based deployment scripts that bring up the MediaWiki instance and all indices in a reproducible configuration. Third, a cognitive memory layer performs tiered retrieval and maintains an episodic store of reusable lessons distilled from experiment traces, such as run logs, diffs, and evaluator feedback, to reduce repeated error modes and accelerate convergence.
+
+Praxium is intentionally modular. It supports pluggable evaluators, knowledge backends, and coding agents, enabling the same iteration loop to be applied across domains where progress is defined by executable outcomes and measurable objectives. We instantiate this design and evaluate it on two complementary benchmarks, MLE-Bench and ALE-Bench, and we use these instantiations to study end-to-end performance, cost, and ablations of the search, knowledge, and memory components. Beyond these benchmarks, the same interfaces generalize to additional tasks by swapping the evaluator and the knowledge sources.
+
+\paragraph{Contributions.}
+This paper makes the following contributions:
+\begin{enumerate}[leftmargin=1.2em]
+  \item An end-to-end framework that converts heterogeneous knowledge into executable software via evaluator-grounded experimentation and iterative improvement.
+  \item A git-native experimentation engine that represents each attempt as an isolated, reproducible branch with explicit provenance.
+  \item A knowledge acquisition and representation pipeline hosted in MediaWiki that converts heterogeneous sources into a typed, workflow-oriented knowledge base usable at runtime.
+  \item A cognitive memory system that combines tiered retrieval with episodic learning from experiment traces to reduce repeated failures and accelerate iteration.
+  \item A modular architecture with pluggable evaluators and knowledge sources, demonstrated through benchmark instantiations and ablations, together with a released knowledge package containing a MediaWiki dump, Neo4j and Weaviate snapshots, and Docker-based deployment scripts for reproducing the full stack. The released knowledge base is populated from over 2{,}000 widely used Data and ML repositories, with selection criteria defined later.
+\end{enumerate}
+
+\section{Framework Overview}
+
+At a high level, Praxium exposes a user-facing \texttt{Expert} API:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{learn}: ingest knowledge sources (e.g., repos) into the knowledge system.
+  \item \textbf{build}: run an experiment loop to produce a working solution.
+  \item \textbf{deploy}: adapt a solution to a target deployment strategy and return a unified runtime interface.
+\end{itemize}
+
+Internally, the build process is orchestrated by an \texttt{OrchestratorAgent} that composes four pluggable subsystems:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{SearchStrategy}: how we generate and select candidate solutions (e.g., LLM-steered tree search).
+  \item \textbf{ContextManager}: what context we pass into solution generation and implementation (legacy vs.\ cognitive).
+  \item \textbf{KnowledgeSearch}: how we retrieve domain knowledge at runtime (legacy LLM-navigation vs.\ hybrid KG search).
+  \item \textbf{CodingAgent}: which code generator applies edits (e.g., Aider, Claude Code, Gemini).
+\end{itemize}
+
+This modular design is intentional. It allows Praxium to swap out components without changing the solve loop or the benchmark harnesses.
+
+\section{Formalization (Notation and Algorithms)}
+
+This section introduces notation and formal operators for the full Praxium framework. The goal is to make the system comparable to prior work in program synthesis, agentic search, and black-box optimization by stating (i) the objects Praxium manipulates, (ii) the objective it optimizes, and (iii) the algorithms it runs.
+
+\subsection{Task model and objective}
+
+We model each benchmark instance as a \textbf{task} $t \in \mathcal{T}$ with a black-box execution-and-scoring interface. In the codebase, this is implemented by a \texttt{ProblemHandler} (and optionally an \texttt{Evaluator}), but for formalization we treat it as an environment:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Goal / objective}: $g$ is a natural-language goal (optionally with constraints). Praxium may also represent this as a structured \texttt{Objective} / \texttt{Goal}.
+  \item \textbf{Budget progress}: $\beta_i \in [0,1]$ is the normalized progress fraction at iteration $i$ (derived from time / iteration / cost budgets).
+  \item \textbf{Problem context}: $P_t(\beta)$ returns the task description string shown to the agent at a given budget progress (budget-aware in MLE).
+  \item \textbf{Execution + scoring}: $\mathrm{Run}_t(c)$ executes a code artifact $c$ (a repository state in an experiment branch) and returns a result tuple:
+\end{itemize}
+
+\[
+r = (\text{had\_error},\; y,\; o,\; m,\; f)
+\]
+
+where $y \in \mathbb{R}$ is the score, $o$ is runtime output, $m$ is an error message/details (if any), and $f$ is optional evaluator feedback.
+
+Many benchmarks define either a maximize or minimize objective. We normalize this with a sign $s_t \in \{+1,-1\}$ and define the \textbf{normalized utility}:
+
+\[
+J_t(c) = s_t \cdot y_t(c)
+\]
+
+so Praxium can always be described as maximizing $J_t$.
+
+Finally, we define an \textbf{experiment history} after iteration $i$ as:
+
+\[
+H_i = \{e_1,\dots,e_{i-1}\},\quad e_j = (b_j,\; u_j,\; y_j,\; \text{had\_error}_j,\; m_j,\; f_j)
+\]
+
+where $b_j$ is the branch identifier and $u_j$ is the natural-language solution specification used to generate code for that branch.
+
+\subsection{Knowledge grounding as retrieval operators}
+
+Let $\mathcal{G}=(\mathcal{V},\mathcal{E})$ be a typed knowledge graph where each page/node $v \in \mathcal{V}$ has:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item an ID and title,
+  \item a type in $\{\text{Workflow},\text{Principle},\text{Implementation},\text{Environment},\text{Heuristic}\}$,
+  \item overview/content text (and sometimes code snippets),
+  \item typed edges in $\mathcal{E}$ (e.g., \texttt{STEP}, \texttt{IMPLEMENTED\_BY}, \texttt{USES\_HEURISTIC}, \texttt{REQUIRES\_ENV}).
+\end{itemize}
+
+Praxium uses a retrieval backend that supports at least:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item $\mathrm{Search}(q, F)\rightarrow \langle (v_k,\mathrm{score}_k)\rangle$: semantic/graph search for a query $q$ under filters $F$,
+  \item $\mathrm{GetPage}(\text{id})\rightarrow v$: fetch full content for a page by ID/title,
+  \item optional graph traversal $\mathrm{Traverse}(v)$ to collect linked knowledge.
+\end{itemize}
+
+The output of retrieval is a \textbf{knowledge packet} $K$ (implemented as \texttt{KGKnowledge}) containing:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item tier label (Tier 1 / 2 / 3),
+  \item confidence (retrieval score),
+  \item provenance metadata (\texttt{query\_used}, \texttt{source\_pages}),
+  \item structured workflow (if any), otherwise a list of relevant principles,
+  \item optional error-recovery attachments (heuristics + alternative implementations).
+\end{itemize}
+
+\subsection{Core solve loop (Orchestrator)}
+
+At the top level, Praxium repeatedly builds context and executes experiments until a stop condition fires. In the codebase this is \texttt{OrchestratorAgent.solve()} plus a chosen \texttt{SearchStrategy}.
+
+\begin{quote}
+\textbf{Algorithm 1: Praxium solve loop (orchestrator-level)}
+\begin{verbatim}
+Inputs:
+  - task handler H_t (problem context + run + stop)
+  - search strategy S (linear or tree)
+  - context manager M (legacy or cognitive)
+  - budgets (iterations/time/cost)
+
+Initialize i = 0
+while i < N:
+  beta_i = budget_progress(time, i, cost)
+  if Stop_t(beta_i) or beta_i >= 1: break
+
+  x_i = M.get_context(beta_i)         # includes P_t(beta_i), knowledge, and history
+  if M.should_stop(): break        # only meaningful for cognitive mode
+
+  S.run(x_i, beta_i)                  # executes >=1 experiments and updates its history
+  i = i + 1
+
+return best experiment in S.history (maximizing J_t)
+\end{verbatim}
+\end{quote}
+
+This formalization makes explicit that Praxium is a \textbf{search over code artifacts} driven by repeated experiments and task-defined scoring.
+
+\subsection{Implement-and-debug loop (SearchStrategy)}
+
+Both linear and tree search ultimately execute the same inner loop: create an isolated branch, implement a solution, run it, and optionally debug it for a bounded number of tries. In the codebase this is \texttt{SearchStrategy.\_implement\_n\_debug()}.
+
+\begin{quote}
+\textbf{Algorithm 2: Implement-and-debug loop (branch-level)}
+\begin{verbatim}
+Inputs:
+  - solution spec u
+  - context x (problem + knowledge + history)
+  - debug budget D
+  - branch name b and parent branch p
+
+session = create_experiment_session(branch=b, parent=p)
+r = implement_solution(u, x, session)          # codegen + Run_t
+
+for k in 1..D:
+  if r.had_error and r.continue_debugging:
+    r = debug_solution(u, x, r.error_details, session)
+  else:
+    break
+
+finalize_session(session)                      # commits + push + cleanup
+return r
+\end{verbatim}
+\end{quote}
+
+\subsection{LLM-steered tree search (one concrete instantiation)}
+
+For completeness, we formalize the LLM-steered tree search used in MLE/ALE configurations. Let $T=(\mathcal{N},\mathcal{A})$ be a tree of nodes $\mathcal{N}$, where each node stores a solution spec $u(n)$ and an optional experiment result $e(n)$.
+
+At each outer iteration, the strategy:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Prune}: optionally terminates some leaf nodes using an LLM conditioned on $(P_t(\beta_i),K_i,H_i)$.
+  \item \textbf{Expand}: chooses nodes to expand (exploration vs.\ exploitation) and generates new child solution specs via an LLM ensemble.
+  \item \textbf{Select}: selects top-$k$ leaf nodes to execute as experiments (again using an LLM conditioned on context).
+\end{itemize}
+
+This can be viewed as a learned proposal distribution over solution specs $u$, combined with black-box evaluation through $\mathrm{Run}_t(\cdot)$.
+
+\subsection{Cognitive memory (tiered retrieval + episodic learning + decisions)}
+
+When the cognitive context manager is enabled, Praxium augments the loop with a controller state $C_i$ containing: the goal $g$, a knowledge packet $K_i$, the last experiment result $e_{i-1}$, episodic insights $Z_i$, and meta statistics (e.g., consecutive failures).
+
+The controller defines:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item $\mathrm{TieredRetrieve}(g, e_{i-1})\rightarrow K_i$: Tier 1/2 retrieval, plus Tier 3 augmentation after failures,
+  \item $\mathrm{UpdateEpisodic}(e_{i-1})\rightarrow E$: store generalized lessons from errors/successes,
+  \item $\pi(C_i)\in\{\textsc{Retry},\textsc{Pivot},\textsc{Complete}\}$: an LLM policy over iteration-level actions.
+\end{itemize}
+
+\begin{quote}
+\textbf{Algorithm 3: Cognitive controller step (per experiment)}
+\begin{verbatim}
+Inputs: goal g, current knowledge K, episodic store E, last result e
+
+if e.had_error:
+  E.add(ExtractError(g, e.error_message))
+  K = Tier3(g, e.error_message, K)                 # add error heuristics + alternatives
+else if e.feedback is non-empty:
+  E.add(ExtractSuccess(g, e.feedback))
+
+Z = RetrieveEpisodic(E, g, e.error_message, e.feedback)
+a = DecideAction(g, K, e, Z)                        # RETRY / PIVOT / COMPLETE
+
+if a == PIVOT:
+  K = TieredRetrieve(g, exclude_current_workflow=True)
+
+return (a, K, Z)
+\end{verbatim}
+\end{quote}
+
+The key property is that both the coding agent and the decision maker are grounded in the same rendered context, and Tier 3 explicitly records provenance via \texttt{query\_used} and \texttt{source\_pages}.
+
+\section{Experimentation Engine}
+
+\subsection{Git-native experiment isolation}
+
+Praxium models each experiment as a \textbf{git branch}. Concretely, an \texttt{ExperimentWorkspace} initializes a git repo and creates isolated \texttt{ExperimentSession}s. Each session:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item clones the workspace,
+  \item checks out a parent branch (to inherit code),
+  \item creates a new experiment branch,
+  \item calls a configured coding agent to implement the candidate solution,
+  \item runs the benchmark handler, and
+  \item commits outputs and pushes the branch for reproducibility and downstream reuse.
+\end{itemize}
+
+This makes experiments debuggable. It also enables tree search over solutions without losing provenance.
+
+\subsection{Search strategies}
+
+Praxium includes two search strategies:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Linear search}: generate a single solution per iteration and refine based on history.
+  \item \textbf{LLM-steered tree search}: maintain a tree of solution candidates, expand nodes with new ideas, prune unpromising leaves, and run selected leaves in parallel.
+\end{itemize}
+
+The tree search has three LLM-mediated decisions:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Generation}: propose diverse candidate solutions.
+  \item \textbf{Selection}: pick which nodes to run next based on expected improvement and diversity.
+  \item \textbf{Pruning}: remove leaves that appear unlikely to improve given history and knowledge.
+\end{itemize}
+
+This design is practical. It allows fast exploration early and exploitation later, while staying compatible with strict evaluation loops (e.g., ALE's fixed iteration budget).
+
+\section{Knowledge System}
+
+Praxium's knowledge system is designed to turn unstructured codebases into structured, searchable expertise that can be reused during builds.
+
+\subsection{Knowledge acquisition: Repo $\rightarrow$ typed wiki pages}
+
+The \texttt{KnowledgePipeline} coordinates a two-stage flow:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Stage 1 (Ingestors)}: parse a source (primarily a git repo) into a set of \texttt{WikiPage}s.
+  \item \textbf{Stage 2 (Merger)}: merge the proposed pages into the main KG (create new pages or merge into existing ones).
+\end{itemize}
+
+For repositories, \texttt{RepoIngestor} runs a two-branch, multi-phase pipeline:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Branch 1 (workflow-based extraction)}: find workflows from READMEs and examples; then trace code paths to write paired Principle+Implementation pages; then extract environments and heuristics; finally run an audit step.
+  \item \textbf{Branch 2 (orphan mining)}: identify useful files not reached by workflow tracing, triage them deterministically, ask an agent to review ambiguous cases, create pages for approved orphans, and verify coverage.
+\end{itemize}
+
+This design reduces ``knowledge holes'' that arise when only top-down workflows are extracted.
+
+\subsection{Knowledge representation: a typed wiki schema}
+
+Praxium uses a typed schema with five page types:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Workflow}: an ordered recipe (steps).
+  \item \textbf{Principle}: theory-level concept.
+  \item \textbf{Implementation}: concrete API / code reference (often includes code snippets).
+  \item \textbf{Environment}: dependencies and system constraints.
+  \item \textbf{Heuristic}: tips and optimizations.
+\end{itemize}
+
+The schema is a directed structure (Workflow $\rightarrow$ Principle $\rightarrow$ Implementation) with heuristics attachable at multiple levels and environment requirements attached to implementations. This structure matters because it bounds context and makes retrieval compositional.
+
+\subsection{Runtime retrieval backends}
+
+Praxium ships two knowledge-search backends:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Legacy: KG LLM Navigation} (\texttt{\detokenize{kg_llm_navigation}}). Stores a graph in Neo4j and uses an LLM to navigate neighbor nodes for a query. This backend can be seeded from a compact JSON graph (e.g., \texttt{\detokenize{benchmarks/mle/data/kg_data.json}}).
+  \item \textbf{Hybrid: KG Graph Search} (\texttt{\detokenize{kg_graph_search}}). Uses Weaviate embeddings for semantic retrieval and Neo4j for graph enrichment. It optionally applies LLM reranking. This backend is designed for typed wiki pages and supports richer workflow traversal.
+\end{itemize}
+
+These backends allow a continuum: fast legacy graph navigation for lightweight setups vs.\ hybrid semantic+graph retrieval when a full wiki KG is available.
+
+\section{Cognitive Memory System (Optional, Workflow-Aware)}
+
+Praxium includes an opt-in cognitive memory layer implemented as a context manager (\texttt{\detokenize{context_manager: cognitive}}). This subsystem is designed to eliminate sharp edges in long-horizon solving: lost feedback, opaque fallbacks, and untraceable retrieval behavior.
+
+\subsection{Tiered knowledge retrieval}
+
+The cognitive controller retrieves knowledge in three tiers:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Tier 1 (exact workflow)}: find a matching workflow via semantic search, then traverse the workflow's ordered steps to collect linked principles, implementations, heuristics, and environments.
+  \item \textbf{Tier 2 (relevant principles)}: if no workflow match exists, return relevant principles and their linked implementations/heuristics (without fabricating a workflow).
+  \item \textbf{Tier 3 (error recovery)}: after a failure, generate error-targeted queries, retrieve error-specific heuristics and alternative implementations, and add them to the existing knowledge packet.
+\end{itemize}
+
+Critically, Tier 3 records provenance: it appends the exact error queries into a \texttt{query\_used} field and adds the retrieved source page IDs into \texttt{source\_pages}. This supports auditability and reproducibility.
+
+\subsection{Episodic memory: learning from experiments}
+
+In addition to KG retrieval, the cognitive controller maintains an episodic store of reusable insights. After each experiment:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item on \textbf{failure}, an LLM generalizes the error into a reusable lesson with trigger conditions and suggested fixes;
+  \item on \textbf{success}, an LLM extracts best-practice insights from evaluator feedback.
+\end{itemize}
+
+These insights are stored in a vector database (Weaviate) with a JSON fallback. On subsequent iterations, an LLM generates an episodic retrieval query conditioned on the current goal and the most recent error/feedback, then ranks candidate insights for applicability.
+
+\subsection{LLM-based decision making}
+
+After each experiment, the controller asks an LLM to decide one of:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{RETRY}: try again with the current knowledge/workflow,
+  \item \textbf{PIVOT}: re-retrieve knowledge while excluding the current workflow, or
+  \item \textbf{COMPLETE}: stop early because the goal is achieved.
+\end{itemize}
+
+The decision is grounded in the same unified context blob that is sent to the coding agent (goal, knowledge packet, last experiment state, and episodic insights). This keeps decisions interpretable.
+
+\section{Evaluation}
+
+We evaluate Praxium on two benchmarks that capture distinct real-world software-building regimes.
+
+\subsection{MLE-Bench (Kaggle-style ML competitions)}
+
+\textbf{Task}: produce a Python solution that trains on provided competition data and writes a \texttt{\detokenize{final_submission.csv}} in the expected format.
+
+\textbf{Execution protocol} (as implemented in the benchmark handler):
+
+\begin{itemize}[leftmargin=1.2em]
+  \item run \textbf{debug mode} first (\texttt{\detokenize{python main.py --debug}}) with a strict runtime cap,
+  \item validate the submission file format,
+  \item run \textbf{full mode} (\texttt{\detokenize{python main.py}}) with a longer runtime budget,
+  \item grade the output submission on the competition's hidden/private split.
+\end{itemize}
+
+\textbf{Stop condition}: stop early if the run achieves \textbf{any medal} according to the MLE-Bench grading library.
+
+\textbf{Reported metrics}:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Private score}: returned by the benchmark grader.
+  \item \textbf{Medal rate}: fraction of competitions where any medal is achieved.
+  \item \textbf{Cost}: cumulative LLM usage cost tracked by the framework.
+\end{itemize}
+
+\textbf{Results}: \emph{[TODO: insert your MLE-Bench results table: competitions, private scores, medals, cost].}
+
+\subsection{ALE-Bench (AtCoder heuristic contests)}
+
+\textbf{Task}: produce a C++ (\texttt{cpp23}) solution in \texttt{\detokenize{main.cpp}} to maximize/minimize a contest-defined score under a strict per-run time limit.
+
+\textbf{Execution protocol}:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item compile and run in the benchmark's Docker environment,
+  \item if the solution is accepted, run it multiple times and average the score to reduce variance,
+  \item evaluate on a private test set to obtain final rank.
+\end{itemize}
+
+\textbf{Reported metrics}:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Final rank} on the private evaluation.
+  \item \textbf{Rank percentile}: \texttt{final\_rank} / \texttt{number\_of\_contestants}.
+  \item \textbf{Private absolute score} (contest objective value).
+  \item \textbf{Cost}: cumulative LLM usage cost.
+\end{itemize}
+
+\textbf{Results}: \emph{[TODO: insert your ALE-Bench results table: problems, rank, percentile, score, cost].}
+
+\section{Discussion}
+
+\subsection{Why MLE-Bench and ALE-Bench are complementary}
+
+MLE-Bench stresses data engineering, model training, file I/O contracts, and long runtimes. ALE-Bench stresses algorithmic design, tight time limits, and stochastic optimization. Together they expose different sharp edges in agent frameworks: brittle file outputs, poor runtime reasoning, lack of iterative improvement, and inability to reuse domain knowledge.
+
+\subsection{What we expect memory to change}
+
+In Praxium, memory is not a monolith. The system supports:
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{short-horizon memory} (recent/top experiment summaries),
+  \item \textbf{domain memory} (KG retrieval), and
+  \item \textbf{self-memory} (episodic insights from past experiments).
+\end{itemize}
+
+We expect the cognitive memory layer to reduce repeated failure modes and shorten time-to-success on tasks with recurring errors (dependency issues, common API misuse, evaluation contract errors). We also expect provenance tracking to make benchmark runs auditable.
+
+\section{Limitations}
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{External services}: the full KG graph search relies on Neo4j + Weaviate and may require infrastructure setup.
+  \item \textbf{LLM dependence}: performance depends on the underlying LLMs used for idea generation, coding, reranking, and decisions.
+  \item \textbf{Benchmark mismatch}: some real-world constraints (security policies, proprietary APIs, long-term maintenance) are not captured by MLE/ALE.
+\end{itemize}
+
+\section{Conclusion}
+
+Praxium is a framework for building software by running experiments, using structured knowledge, and optionally learning from experience. Its core contributions are a git-native experimentation engine, a scalable knowledge acquisition and retrieval system, and a workflow-aware cognitive memory layer with tiered retrieval and episodic learning. The framework is designed to be modular and auditable. We recommend reporting benchmark results with both performance and cost, and we provide a clear execution protocol for MLE-Bench and ALE-Bench to enable reproducible evaluation.
+
+\appendix
+
+\section{Reproducibility checklist}
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Configuration}: record the exact mode configs (search strategy params, coding agent model, knowledge search backend).
+  \item \textbf{KG snapshot}: record the wiki snapshot / KG index version used for the run.
+  \item \textbf{LLM versions}: record exact model strings (including provider prefixes) for all LLM calls.
+  \item \textbf{Randomness}: record MLE seed and ALE run counts.
+\end{itemize}
+
+\section{Suggested tables to include in v1}
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \textbf{Table 1}: MLE-Bench results per competition (private score, medal, cost, iterations).
+  \item \textbf{Table 2}: ALE-Bench results per problem (rank, percentile, private score, cost, iterations).
+  \item \textbf{Table 3}: Ablation: KG on/off; cognitive context manager on/off.
+\end{itemize}
+
+\end{document}
+
+

--- a/src/core/prompt_loader.py
+++ b/src/core/prompt_loader.py
@@ -1,0 +1,72 @@
+"""
+Prompt loader (tunable, minimal)
+===============================
+
+We externalize large prompt strings into plain text files so they are:
+- easy to audit and tune without touching python logic
+- reusable across different call sites (builders, ideation, coding)
+- testable (we can assert prompt files exist and are loaded)
+
+Override mechanism
+------------------
+By default, prompts are loaded from the repository under `src/<relative_path>`.
+
+If you set `PRAXIUM_PROMPTS_DIR=/some/dir`, we will load prompts from:
+  /some/dir/<relative_path>
+
+This lets you tune prompts in a separate directory (e.g. mounted volume) without
+editing or forking the codebase.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+
+
+_DEFAULT_PROMPTS_ROOT = Path(__file__).resolve().parents[1]  # .../src
+
+
+def _get_prompts_root() -> Path:
+    """Return the root directory where prompt files are loaded from."""
+    override = os.environ.get("PRAXIUM_PROMPTS_DIR", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return _DEFAULT_PROMPTS_ROOT
+
+
+@lru_cache(maxsize=256)
+def load_prompt(relative_path: str) -> str:
+    """
+    Load a prompt file as text.
+
+    Args:
+        relative_path: Path relative to `src/`, e.g. "repo_memory/prompts/infer_repo_model_initial.md"
+    """
+    rel = (relative_path or "").lstrip("/").strip()
+    if not rel:
+        raise ValueError("load_prompt(relative_path) requires a non-empty path")
+
+    path = _get_prompts_root() / rel
+    if not path.exists():
+        raise FileNotFoundError(f"Prompt file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def render_prompt(template: str, variables: Dict[str, str]) -> str:
+    """
+    Render a prompt template using a tiny `{{var}}` replacement scheme.
+
+    Why not `str.format`?
+    - Our prompts frequently include JSON schemas with `{}` which would require
+      escaping and is extremely error-prone.
+
+    This replacement is intentionally simple and explicit.
+    """
+    text = template or ""
+    for key, value in (variables or {}).items():
+        text = text.replace("{{" + str(key) + "}}", str(value))
+    return text
+

--- a/src/execution/experiment_workspace/experiment_workspace.py
+++ b/src/execution/experiment_workspace/experiment_workspace.py
@@ -195,7 +195,13 @@ class ExperimentWorkspace:
         seeded repos often have important ignore rules already.
         """
         gitignore_path = os.path.join(self.workspace_dir, ".gitignore")
-        required_lines = ["sessions/*", "*.log"]
+        # Keep session clones out of the workspace repo.
+        # Keep generic logs ignored, BUT explicitly allow `changes.log` so it is committed
+        # into experiment branches as an audit trail (RepoMemory observability).
+        #
+        # IMPORTANT: Ordering matters in .gitignore.
+        # The negation rule (`!changes.log`) must appear after `*.log`.
+        required_lines = ["sessions/*", "*.log", "!changes.log"]
 
         existing = ""
         if os.path.exists(gitignore_path):
@@ -225,7 +231,8 @@ class ExperimentWorkspace:
     def create_experiment_session(
         self, 
         branch_name: str, 
-        parent_branch_name: str = "main"
+        parent_branch_name: str = "main",
+        llm=None,
     ) -> ExperimentSession:
         """
         Create a new experiment session.
@@ -254,6 +261,7 @@ class ExperimentWorkspace:
             coding_agent_config=self.coding_agent_config,
             parent_branch_name=parent_branch_name,
             branch_name=branch_name,
+            repo_memory_llm=llm,
         )
         
         return session

--- a/src/execution/ideation/__init__.py
+++ b/src/execution/ideation/__init__.py
@@ -1,0 +1,8 @@
+"""
+Ideation utilities
+=================
+
+This package holds code that helps the engine generate solution specs ("ideation")
+before handing execution off to coding agents.
+"""
+

--- a/src/execution/ideation/repo_memory_react.py
+++ b/src/execution/ideation/repo_memory_react.py
@@ -1,0 +1,190 @@
+"""
+RepoMemory ReAct loop (engine-mediated)
+======================================
+
+This module implements an engine-mediated loop for ideation:
+- The ideation LLM starts with RepoMemory Summary+TOC.
+- It may request specific sections (by ID) to ground its proposal.
+- The engine (this code) fetches the section content and returns it.
+- The loop ends when the model returns a final solution.
+
+Why do this in the engine?
+- Most LLM backends used for ideation are plain text-only (no native tool calling).
+- It keeps section retrieval auditable and deterministic on the engine side.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Tuple
+
+import git
+
+from src.core.llm import LLMBackend
+from src.core.prompt_loader import load_prompt, render_prompt
+from src.repo_memory import RepoMemoryManager
+
+
+def _extract_json_obj(text: str) -> Dict[str, Any]:
+    """
+    Parse a JSON object from model output.
+
+    We prefer strict parsing, but also support a fallback of extracting the first
+    {...} block (models sometimes add stray whitespace).
+    """
+    raw = (text or "").strip()
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+        raise ValueError("Expected a JSON object")
+    except Exception:
+        pass
+
+    m = re.search(r"\{[\s\S]*\}", raw)
+    if not m:
+        raise ValueError("Model did not return a JSON object")
+    data = json.loads(m.group(0))
+    if not isinstance(data, dict):
+        raise ValueError("Expected a JSON object")
+    return data
+
+
+def _dedupe_preserve_order(items: List[str]) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for x in items:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def ideate_solution_with_repo_memory_react(
+    *,
+    llm: LLMBackend,
+    model: str,
+    repo: git.Repo,
+    base_branch: str,
+    problem: str,
+    workflow_guidance: str = "",
+    history_summary: str = "",
+    additional_knowledge: str = "",
+    output_requirements: str = "",
+    max_rounds: int = 6,
+    section_max_chars: int = 8000,
+    toc_max_chars: int = 3000,
+) -> Tuple[str, List[str]]:
+    """
+    Generate a solution spec via a RepoMemory-aware ReAct loop.
+
+    Returns:
+        (solution_text, sections_consulted)
+    """
+    doc = RepoMemoryManager.load_from_git_branch(repo, base_branch) or {}
+    repo_memory_summary_toc = (
+        RepoMemoryManager.render_summary_and_toc(doc, max_chars=toc_max_chars) if doc else ""
+    )
+
+    template = load_prompt("execution/prompts/ideation_solution_react.md")
+    initial_prompt = render_prompt(
+        template,
+        {
+            "problem": problem or "",
+            "base_branch": base_branch or "",
+            "repo_memory_summary_toc": repo_memory_summary_toc or "(No repo memory available.)",
+            "workflow_guidance": workflow_guidance or "",
+            "history_summary": history_summary or "",
+            "additional_knowledge": additional_knowledge or "",
+            "output_requirements": output_requirements or "",
+        },
+    )
+
+    messages = [{"role": "user", "content": initial_prompt}]
+    consulted: List[str] = []
+
+    for _ in range(max_rounds):
+        # Deterministic: we're running a structured JSON protocol loop.
+        # Lower randomness reduces flakiness and keeps the agent on-format.
+        raw = llm.llm_completion(model=model, messages=messages, temperature=0)
+        try:
+            action = _extract_json_obj(raw)
+        except Exception as e:
+            # Ask the model to retry with strictly valid JSON.
+            messages.append({"role": "assistant", "content": raw})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "Your last message was not valid JSON.\n"
+                        "Reply again with exactly ONE JSON object, matching the protocol.\n"
+                        f"Parsing error: {e}"
+                    ),
+                }
+            )
+            continue
+
+        kind = (action or {}).get("action", "")
+        if kind == "get_section":
+            section_id = str((action or {}).get("section_id", "")).strip()
+            if not section_id:
+                messages.append({"role": "assistant", "content": raw})
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "Missing `section_id`.\n"
+                            "Reply with: {\"action\":\"get_section\",\"section_id\":\"<id>\"} or {\"action\":\"final\",\"solution\":\"...\"}"
+                        ),
+                    }
+                )
+                continue
+
+            consulted.append(section_id)
+            section_text = RepoMemoryManager.get_section(doc, section_id, max_chars=section_max_chars)
+            messages.append({"role": "assistant", "content": raw})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"RepoMemory section '{section_id}':\n\n"
+                        f"{section_text}\n\n"
+                        "Continue. Reply with ONE JSON object only."
+                    ),
+                }
+            )
+            continue
+
+        if kind == "final":
+            solution = (action or {}).get("solution", "")
+            if not isinstance(solution, str):
+                solution = str(solution)
+            return solution, _dedupe_preserve_order(consulted)
+
+        # Unknown action -> retry.
+        messages.append({"role": "assistant", "content": raw})
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"Unknown action '{kind}'.\n"
+                    "Valid actions are: get_section, final.\n"
+                    "Reply with exactly ONE JSON object."
+                ),
+            }
+        )
+
+    # If we hit the limit, return best-effort: ask the model for a final answer once.
+    messages.append(
+        {
+            "role": "user",
+            "content": "You are out of tool rounds. Reply now with {\"action\":\"final\",\"solution\":\"...\"} only.",
+        }
+    )
+    raw = llm.llm_completion(model=model, messages=messages, temperature=0)
+    action = _extract_json_obj(raw)
+    if (action or {}).get("action") == "final":
+        return str((action or {}).get("solution", "")), _dedupe_preserve_order(consulted)
+    return str(raw or ""), _dedupe_preserve_order(consulted)
+

--- a/src/execution/prompts/coding_agent_debug.md
+++ b/src/execution/prompts/coding_agent_debug.md
@@ -1,0 +1,38 @@
+You are a world class developer. Debug the Implemented <solution> for <problem>.
+
+<repository_memory>
+{{repo_memory_brief}}
+
+{{repo_memory_detail_access_instructions}}
+
+OBSERVABILITY REQUIREMENT (do not skip):
+- If you consulted repo memory sections, record which ones in `changes.log`.
+- Add a line exactly like:
+  RepoMemory sections consulted: core.architecture, core.where_to_edit
+- If you did not consult repo memory, write:
+  RepoMemory sections consulted: none
+</repository_memory>
+
+<problem>
+{{problem}}
+</problem>
+
+<solution>
+{{solution}}
+</solution>
+
+current output: {{error_details}}
+
+Requirements:
+- Read the code line by line and understand the logic.
+- Make sure every part of the <solution> is implemented correctly.
+  - Read sections and steps of <solution> carefully and implement them exactly.
+- Do not propose a new solution or drift away from the current implementation for <solution> and only fix the errors.
+- Write clean, functional code, that can be improved iteratively later.
+- Output code and format must be as mentioned in the problem statement.
+- Do not add logics like fallback and functionality discarding to avoid the error. you must fix the error directly.
+- Never and under no circumstances use try except blocks to fix the errors. you should fix the error directly.
+- Beside fixing the current error, read the code and make sure other parts of the code will be run correctly and without errors.
+- Do not change any hyper parameter or logic of the solution to fix the error.
+- Do not ask any questions from the user. just do as you said.
+

--- a/src/execution/prompts/coding_agent_implement.md
+++ b/src/execution/prompts/coding_agent_implement.md
@@ -1,0 +1,55 @@
+You are a world class developer and programmer. Modify the repo or Implement the provided <solution> for <problem>.
+
+Requirements:
+- Write a clean and functional code.
+- You must implement the <solution> exactly as it is provided.
+  - Read Sections and Steps of <solution> carefully and implement them exactly.
+- Output code and format must be as mentioned in the problem statement.
+- Do not write any comments in the code. Just the start of each section.
+- Choose the names of the variables and functions according to the the solution.
+- The code must be highly structured and well organized. Separate sections for different functionalities.
+- Run the code only if asked in the problem context.
+- Use the informaton from knowledge base to develop with less error. under no circumstances deviate from the <solution> provided because of the knowledge base.
+- CRITICAL: Never print or allow interactive or multiline outputs like tqdm, progress bar, etc.
+- You have access to a list of your recent errors that you have made in the past. make sure to no repeat them.
+
+<previous_errors>
+{{previous_errors}}
+</previous_errors>
+
+- Directories:
+  - Codes must be implemented in the current directory and git root.
+  - Experiment Output Data Directory: For the outputs of running the main code like checkpoints, data files and final outputs use Experiment Output Data Directory : "./output_data_{{branch_name}}".
+    -- Always use this path relative and always set it in each implementation.
+  - It is highly critical that not using absolute path for the above directories but if the problem provided absolute folders, it is ok to use them.
+- At the end create a changes.log file and summarize the changes you made to implement the <solution> in a few sentences.
+- CRITICAL: You are an AI code editor. Your ONLY job is to edit code files. Do NOT write any conversational text, explanations, or descriptions. Do not respond with "I'll implement..." or any other conversational text.
+- The most critical part of development: Read the <solution> line by line, understand the logic and details and implement the code exactly as <solution> is provided.
+
+<repository_memory>
+{{repo_memory_brief}}
+
+{{repo_memory_detail_access_instructions}}
+
+OBSERVABILITY REQUIREMENT (do not skip):
+- If you consulted repo memory sections, record which ones in `changes.log`.
+- Add a line exactly like:
+  RepoMemory sections consulted: core.architecture, core.where_to_edit
+- If you did not consult repo memory, write:
+  RepoMemory sections consulted: none
+</repository_memory>
+
+<Relible information from knowledge base>
+{{kg_code_results}}
+<Relible information from knowledge base>
+
+<problem>
+{{problem}}
+</problem>
+
+<solution>
+{{solution}}
+</solution>
+
+- Do not ask any questions from the user. Just implement everything as you said. It is highly critical to implement everything as you said so be through.
+

--- a/src/execution/prompts/ideation_solution_react.md
+++ b/src/execution/prompts/ideation_solution_react.md
@@ -1,0 +1,48 @@
+You are a world class problem solver.
+
+Your job: generate a complete, implementable solution for the PROBLEM below.
+
+You have access to a **repository memory** (RepoMemory) for the base branch you will continue from.
+You can either:
+
+1) Request a RepoMemory section (engine will return it), OR
+2) Finish and return the final solution.
+
+### Output protocol (STRICT)
+You MUST output a single JSON object and nothing else.
+
+- To request a section:
+  {"action":"get_section","section_id":"core.architecture"}
+
+- To finish:
+  {"action":"final","solution":"...full solution text here..."}
+
+No markdown fences. No extra keys. No commentary outside JSON.
+
+IMPORTANT: JSON strings cannot contain literal newlines. If your solution needs
+multiple lines, encode newlines as \\n inside the JSON string.
+
+### PROBLEM
+{{problem}}
+
+### REPOSITORY MEMORY (Summary + TOC) (base branch: {{base_branch}})
+{{repo_memory_summary_toc}}
+
+### WORKFLOW GUIDANCE (optional; from knowledge base)
+{{workflow_guidance}}
+
+### PREVIOUS EXPERIMENTS (optional)
+{{history_summary}}
+
+### ADDITIONAL KNOWLEDGE (optional)
+{{additional_knowledge}}
+
+### OUTPUT REQUIREMENTS (optional)
+{{output_requirements}}
+
+Now decide:
+- If you will change code, do NOT guess where to edit. First request `core.where_to_edit` (if present in the TOC).
+- If your solution touches behavior/output/contracts, also request `core.invariants` or `core.gotchas` (if present) before finalizing.
+- Keep tool use efficient: usually 1-3 section requests is enough.
+- Otherwise, output {"action":"final", ...} with the full solution.
+

--- a/src/expert.py
+++ b/src/expert.py
@@ -259,6 +259,12 @@ class Expert:
             coding_agent=coding_agent,
             is_kg_active=self.knowledge_search.is_enabled(),
             knowledge_search=self.knowledge_search if self.knowledge_search.is_enabled() else None,
+            # IMPORTANT:
+            # - Many callers (CLI + E2E tests) pass `output_path` expecting the final repo to live there.
+            # - The orchestration layer owns the experiment workspace (a git repo with branches).
+            # - Therefore, when `output_path` is provided, we must use it as the workspace directory
+            #   so `solution.code_path` points at a real git repo (with `.praxium/repo_memory.json`).
+            workspace_dir=output_path,
             starting_repo_path=starting_repo_path,
         )
         

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -37,7 +37,7 @@ class ControllerConfig:
     state_file_path: str = ".praxium_state.md"
     max_error_length: int = 1000
     max_fact_length: int = 200
-    
+
     # -------------------------------------------------------------------------
     # Retrieval tuning (Tier 1 / 2 / 3)
     # -------------------------------------------------------------------------

--- a/src/repo_memory/builders.py
+++ b/src/repo_memory/builders.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+from src.core.prompt_loader import load_prompt, render_prompt
 
 
 class LLMLike(Protocol):
@@ -74,30 +77,102 @@ def build_repo_map(
     - a stable "repo map" for coding agents, and
     - an input to the agentic repo-model inference workflow.
     """
+    # IMPORTANT:
+    # - RepoMemory is committed into git branches and should be portable across machines/runs.
+    # - Experiments run inside a temporary clone (`sessions/<branch>`), which is deleted on close.
+    #   This means persisting absolute paths like `/tmp/.../sessions/...` into memory is wrong.
+    #
+    # Therefore:
+    # - We store `repo_map["repo_root"]` as "." (portable, stable).
+    # - When possible, we enumerate files via git (so the RepoMap matches what is committed and
+    #   respects `.gitignore`). We still keep a filesystem `os.walk` fallback for non-git dirs.
     repo_root = os.path.abspath(repo_root)
     file_paths: List[str] = []
     languages: Dict[str, int] = {}
 
-    root_depth = repo_root.rstrip(os.sep).count(os.sep)
-    for dirpath, dirnames, filenames in os.walk(repo_root):
-        # Prune ignored dirs in-place to prevent descending into them.
-        dirnames[:] = [d for d in dirnames if d not in _IGNORE_DIRS]
+    # Preferred enumeration path: ask git for the file list.
+    #
+    # Why:
+    # - RepoMap must reflect the actual repo state (tracked + untracked-not-ignored),
+    #   not transient/ignored artifacts like `sessions/*` or `.praxium/*`.
+    # - This also avoids phantom files such as `changes.log` when it is ignored.
+    #
+    # We still explicitly filter out `changes.log` because it is observability metadata,
+    # not part of "what does the repo do?".
+    git_files: Optional[List[str]] = None
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", repo_root, "ls-files", "--cached", "--others", "--exclude-standard"],
+            stderr=subprocess.DEVNULL,
+        ).decode("utf-8", "replace")
+        git_files = [ln.strip() for ln in out.splitlines() if ln.strip()]
+    except Exception:
+        git_files = None
 
-        depth = dirpath.rstrip(os.sep).count(os.sep) - root_depth
-        if depth > max_depth:
-            dirnames[:] = []
-            continue
-
-        for fname in filenames:
+    if git_files is not None:
+        for rel_path in git_files:
             if len(file_paths) >= max_files:
                 break
-            abs_path = os.path.join(dirpath, fname)
-            rel_path = os.path.relpath(abs_path, repo_root)
+
+            # git always uses "/" separators; keep paths in that canonical form.
+            #
+            # IMPORTANT: Do NOT use `lstrip("./")` here.
+            # `lstrip` removes *any* leading '.' characters, which corrupts dotfiles:
+            # - ".gitignore" would become "gitignore"
+            # - ".praxium/repo_memory.json" would become "praxium/repo_memory.json"
+            # That breaks portability and also defeats our `.praxium` exclusion filter.
+            if rel_path.startswith("./"):
+                rel_path = rel_path[2:]
+            if not rel_path:
+                continue
+
+            # Explicitly exclude observability metadata from the semantic repo map.
+            if rel_path == "changes.log":
+                continue
+
+            # Exclude meta directories (RepoMemory itself, sessions, VCS dirs, etc.).
+            top_level = rel_path.split("/", 1)[0]
+            if top_level in _IGNORE_DIRS:
+                continue
+
+            # Keep behavior consistent with the filesystem traversal by enforcing a max depth.
+            # Depth is measured as number of path separators.
+            if rel_path.count("/") > max_depth:
+                continue
+
             file_paths.append(rel_path)
 
-            _, ext = os.path.splitext(fname)
+            _, ext = os.path.splitext(rel_path)
             if ext:
                 languages[ext.lower()] = languages.get(ext.lower(), 0) + 1
+    else:
+        # Fallback enumeration path: walk the filesystem.
+        # This is used for non-git directories (rare in the experimentation engine).
+        root_depth = repo_root.rstrip(os.sep).count(os.sep)
+        for dirpath, dirnames, filenames in os.walk(repo_root):
+            # Prune ignored dirs in-place to prevent descending into them.
+            dirnames[:] = [d for d in dirnames if d not in _IGNORE_DIRS]
+
+            depth = dirpath.rstrip(os.sep).count(os.sep) - root_depth
+            if depth > max_depth:
+                dirnames[:] = []
+                continue
+
+            for fname in filenames:
+                if len(file_paths) >= max_files:
+                    break
+                abs_path = os.path.join(dirpath, fname)
+                rel_path = os.path.relpath(abs_path, repo_root)
+
+                # Explicitly exclude observability metadata from the semantic repo map.
+                if rel_path == "changes.log":
+                    continue
+
+                file_paths.append(rel_path)
+
+                _, ext = os.path.splitext(fname)
+                if ext:
+                    languages[ext.lower()] = languages.get(ext.lower(), 0) + 1
 
     file_paths.sort()
 
@@ -113,14 +188,17 @@ def build_repo_map(
         "Dockerfile",
         "Makefile",
     ]
-    key_files = [p for p in key_file_candidates if os.path.exists(os.path.join(repo_root, p))]
+    # Derive key files from the enumerated file list (portable, avoids filesystem drift).
+    key_file_set = set(file_paths)
+    key_files = [p for p in key_file_candidates if p in key_file_set]
 
     # Simple entrypoint heuristics (cheap and usually correct).
     entrypoint_names = {"main.py", "app.py", "server.py", "cli.py", "main.cpp", "main.cc", "main.c"}
     entrypoints = [p for p in file_paths if os.path.basename(p) in entrypoint_names]
 
     return {
-        "repo_root": repo_root,
+        # Keep this portable: repo roots are often under /tmp in E2E tests.
+        "repo_root": ".",
         "file_count": len(file_paths),
         "files": file_paths[:2000],  # Keep bounded in memory file.
         "languages_by_extension": dict(sorted(languages.items(), key=lambda kv: kv[1], reverse=True)),
@@ -135,10 +213,81 @@ class EvidenceCheck:
     missing: List[str]
 
 
+def _build_toc_from_sections(sections: Dict[str, Any]) -> List[Dict[str, str]]:
+    """
+    Build a simple Table of Contents from a v2 `sections` dict.
+    
+    This is intentionally lightweight and deterministic:
+    - Sort by section id for stability
+    - Include only id/title/one_liner (no content)
+    """
+    sections = sections or {}
+    toc: List[Dict[str, str]] = []
+    for sid in sorted(sections.keys()):
+        sec = sections.get(sid, {}) or {}
+        toc.append(
+            {
+                "id": sid,
+                "title": (sec.get("title") or sid),
+                "one_liner": (sec.get("one_liner") or ""),
+            }
+        )
+    return toc
+
+
+def _sections_to_flat_claims(sections: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Flatten v2 sections -> a single list of claims (legacy compatibility helper).
+    
+    This is useful when a consumer still expects a v1-style `repo_model.claims[]`.
+    """
+    sections = sections or {}
+    flat: List[Dict[str, Any]] = []
+    for sec in sections.values():
+        for claim in (sec or {}).get("claims", []) or []:
+            if isinstance(claim, dict):
+                flat.append(claim)
+    return flat
+
+
 def _normalize_whitespace(text: str) -> str:
     """Normalize whitespace for fuzzy quote matching (preserves semantics)."""
     # Collapse all whitespace sequences to single space, strip ends
     return " ".join(text.split())
+
+
+def _normalize_punct_whitespace(text: str) -> str:
+    """
+    Normalize whitespace and also remove whitespace around punctuation.
+
+    Why:
+    - LLMs sometimes "flatten" multi-line code into a single-line quote, e.g.:
+        code:  lora_config = LoraConfig(
+                 r=8,
+                 lora_alpha=8,
+               )
+        quote: lora_config = LoraConfig(r=8, lora_alpha=8,
+      This is still grounded, but fails strict substring matching.
+    - We want to tolerate *whitespace-only* differences around punctuation ((), commas, =, etc.)
+      without allowing the model to invent new tokens.
+    """
+    raw = _normalize_whitespace(text or "")
+    # Remove whitespace around common punctuation tokens used in code/config.
+    # Keep this conservative: only punctuation, not alphanumeric boundaries.
+    return re.sub(r"\s*([()\[\]{}.,:;=])\s*", r"\1", raw)
+
+
+def _strip_markdown_backticks(text: str) -> str:
+    """
+    Remove Markdown inline-code backticks.
+    
+    Why:
+    - Repos often wrap identifiers in backticks in README/docs.
+    - LLMs sometimes omit backticks when copying evidence quotes.
+    - Allowing a backtick-stripped fallback keeps evidence grounded while
+      avoiding flaky failures on purely presentational characters.
+    """
+    return (text or "").replace("`", "")
 
 
 def _quote_in_text(quote: str, text: str) -> bool:
@@ -155,7 +304,25 @@ def _quote_in_text(quote: str, text: str) -> bool:
     # Whitespace-normalized match (fallback)
     norm_quote = _normalize_whitespace(quote)
     norm_text = _normalize_whitespace(text)
-    return norm_quote in norm_text
+    if norm_quote and norm_quote in norm_text:
+        return True
+
+    # Markdown backtick-stripped match (fallback)
+    # Keep this narrow: only strip backticks (common LLM mismatch) and still
+    # require substring containment after whitespace normalization.
+    bt_quote = _normalize_whitespace(_strip_markdown_backticks(quote))
+    bt_text = _normalize_whitespace(_strip_markdown_backticks(text))
+
+    if bt_quote and bt_quote in bt_text:
+        return True
+
+    # Punctuation/whitespace normalized match (fallback)
+    #
+    # This specifically addresses cases where the model collapses newlines around punctuation,
+    # e.g. "LoraConfig(r=8, lora_alpha=8," when the file is formatted as multi-line args.
+    pw_quote = _normalize_punct_whitespace(_strip_markdown_backticks(quote))
+    pw_text = _normalize_punct_whitespace(_strip_markdown_backticks(text))
+    return bool(pw_quote) and pw_quote in pw_text
 
 
 def validate_evidence(repo_root: str, repo_model: Dict[str, Any]) -> EvidenceCheck:
@@ -168,11 +335,39 @@ def validate_evidence(repo_root: str, repo_model: Dict[str, Any]) -> EvidenceChe
     repo_root = os.path.abspath(repo_root)
     missing: List[str] = []
 
+    # v2 (book-model) shape: {"summary": "...", "sections": {section_id: {"claims": [...]}}}
+    if isinstance((repo_model or {}).get("sections"), dict):
+        sections = (repo_model or {}).get("sections", {}) or {}
+        for sid, sec in sections.items():
+            claims = (sec or {}).get("claims", []) or []
+            for idx, claim in enumerate(claims):
+                for eidx, ev in enumerate((claim or {}).get("evidence", []) or []):
+                    path = (ev or {}).get("path", "")
+                    quote = (ev or {}).get("quote", "")
+                    if not path or not quote:
+                        missing.append(f"{sid}.claims[{idx}].evidence[{eidx}]: missing path/quote")
+                        continue
+                    abs_path = os.path.join(repo_root, path)
+                    if not os.path.exists(abs_path):
+                        missing.append(f"{sid}.claims[{idx}].evidence[{eidx}]: file not found: {path}")
+                        continue
+                    try:
+                        with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+                            text = f.read()
+                    except Exception:
+                        missing.append(f"{sid}.claims[{idx}].evidence[{eidx}]: unreadable file: {path}")
+                        continue
+                    if not _quote_in_text(quote, text):
+                        missing.append(f"{sid}.claims[{idx}].evidence[{eidx}]: quote not found in {path}")
+
+        return EvidenceCheck(ok=len(missing) == 0, missing=missing)
+
+    # v1 (legacy) shape: {"claims": [...]}
     claims = (repo_model or {}).get("claims", [])
     for idx, claim in enumerate(claims):
-        for eidx, ev in enumerate(claim.get("evidence", []) or []):
-            path = ev.get("path", "")
-            quote = ev.get("quote", "")
+        for eidx, ev in enumerate((claim or {}).get("evidence", []) or []):
+            path = (ev or {}).get("path", "")
+            quote = (ev or {}).get("quote", "")
             if not path or not quote:
                 missing.append(f"claims[{idx}].evidence[{eidx}]: missing path/quote")
                 continue
@@ -223,35 +418,48 @@ def plan_files_to_read(
     key_files = repo_map.get("key_files", [])
     entrypoints = repo_map.get("entrypoints", [])
 
-    prompt = f"""You are inferring a repository's architecture and algorithms.
-
-You will choose up to {max_files_to_read} files to read. Choose files that maximize:
-- understanding of core algorithms/ideas
-- entrypoints (how to run)
-- configuration and evaluation contracts
-
-You MUST return valid JSON only:
-{{
-  "files_to_read": [
-    {{"path": "README.md", "why": "..." }}
-  ]
-}}
-
-Repo key files: {key_files}
-Repo entrypoints: {entrypoints}
-Sample file list (paths): {files}
-"""
-    data = _extract_json(llm.llm_completion(model=model, messages=[{"role": "user", "content": prompt}]))
+    template = load_prompt("repo_memory/prompts/plan_files_to_read.md")
+    prompt = render_prompt(
+        template,
+        {
+            "max_files_to_read": str(max_files_to_read),
+            "key_files_json": json.dumps(key_files),
+            "entrypoints_json": json.dumps(entrypoints),
+            "files_json": json.dumps(files),
+        },
+    )
+    # Deterministic planning: this output is structural JSON, not creative writing.
+    data = _extract_json(
+        llm.llm_completion(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+    )
     chosen = []
     for item in data.get("files_to_read", [])[:max_files_to_read]:
         p = (item or {}).get("path", "")
         if p and p in repo_map.get("files", []):
             chosen.append(p)
-    # Always include key files if present (cheap + high leverage)
-    for p in key_files:
-        if p in repo_map.get("files", []) and p not in chosen:
-            chosen.insert(0, p)
-    return chosen[:max_files_to_read]
+
+    # Always include key files + entrypoints if present (cheap + high leverage).
+    #
+    # Why:
+    # - Key files (README, pyproject, requirements, etc.) often contain the "story" of the repo.
+    # - Entrypoints show the real runtime data flow and output contracts.
+    # - Making this deterministic improves semantic memory quality and reduces dependence
+    #   on the LLM planner picking the obvious files.
+    must_include: List[str] = []
+    for p in list(key_files or []) + list(entrypoints or []):
+        if p and p in repo_map.get("files", []) and p not in must_include:
+            must_include.append(p)
+
+    # Preserve the LLM's ordering for the rest (it often clusters related modules).
+    for p in chosen:
+        if p not in must_include:
+            must_include.append(p)
+
+    return must_include[:max_files_to_read]
 
 
 def infer_repo_model_initial(
@@ -275,38 +483,23 @@ def infer_repo_model_initial(
 
     files_payload = "\n\n".join([f"=== FILE: {p} ===\n{t}" for p, t in file_blobs if t])
 
-    prompt = f"""You are inferring repository memory for an automated coding system.
-
-Return ONLY valid JSON. Every claim MUST include evidence.
-
-CRITICAL: Evidence quotes must be EXACT VERBATIM substrings that appear in the file.
-- Copy quotes character-for-character from the file content below
-- Do NOT paraphrase, summarize, or modify quotes in any way
-- The quote must exist as a continuous substring in the file
-- Shorter quotes (e.g., function signatures, class names) are safer than long ones
-
-Required JSON schema:
-{{
-  "summary": "High-level what the repo does",
-  "entrypoints": [{{"path": "main.py", "how_to_run": "python main.py --help"}}],
-  "where_to_edit": [{{"path": "src/foo.py", "role": "core algorithm implementation"}}],
-  "claims": [
-    {{
-      "kind": "algorithm|architecture|contract|deployment|other",
-      "statement": "...",
-      "confidence": 0.0,
-      "evidence": [{{"path": "path/in/repo.py", "quote": "EXACT verbatim substring from file - copy carefully"}}]
-    }}
-  ]
-}}
-
-RepoMap key files: {repo_map.get("key_files", [])}
-RepoMap entrypoints: {repo_map.get("entrypoints", [])}
-
-FILE CONTENTS (authoritative - copy quotes EXACTLY from here):
-{files_payload}
-"""
-    repo_model = _extract_json(llm.llm_completion(model=model, messages=[{"role": "user", "content": prompt}]))
+    template = load_prompt("repo_memory/prompts/infer_repo_model_initial.md")
+    prompt = render_prompt(
+        template,
+        {
+            "repo_map_key_files_json": json.dumps(repo_map.get("key_files", [])),
+            "repo_map_entrypoints_json": json.dumps(repo_map.get("entrypoints", [])),
+            "files_payload": files_payload,
+        },
+    )
+    # Deterministic: evidence quotes must be exact; reduce randomness to avoid drift.
+    repo_model = _extract_json(
+        llm.llm_completion(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+    )
     return repo_model
 
 
@@ -317,7 +510,7 @@ def infer_repo_model_with_retry(
     repo_map: Dict[str, Any],
     max_file_chars: int = 20000,
     max_files_to_read: int = 20,
-    max_retries: int = 2,
+    max_retries: int = 4,
 ) -> Dict[str, Any]:
     """
     Build a semantic repo model with retry on evidence validation failure.
@@ -325,54 +518,67 @@ def infer_repo_model_with_retry(
     If evidence validation fails, retries with explicit feedback about which
     quotes were invalid, giving the LLM a chance to correct them.
     """
-    repo_model = infer_repo_model_initial(
-        llm=llm,
-        model=model,
-        repo_root=repo_root,
-        repo_map=repo_map,
-        max_file_chars=max_file_chars,
-        max_files_to_read=max_files_to_read,
+    # Plan + read files ONCE and reuse the same file payload for retries.
+    #
+    # Why:
+    # - Evidence failures are usually about mis-copied quotes/paths, not missing files.
+    # - Re-planning on each retry can remove the relevant file from the prompt, making it
+    #   impossible for the model to fix its own evidence.
+    files_to_read = plan_files_to_read(
+        llm, model=model, repo_map=repo_map, max_files_to_read=max_files_to_read
     )
-    
+    file_blobs: List[Tuple[str, str]] = []
+    for rel in files_to_read:
+        abs_path = os.path.join(repo_root, rel)
+        file_blobs.append((rel, _safe_read_text(abs_path, max_chars=max_file_chars)))
+    files_payload = "\n\n".join([f"=== FILE: {p} ===\n{t}" for p, t in file_blobs if t])
+
+    # Initial inference.
+    template = load_prompt("repo_memory/prompts/infer_repo_model_initial.md")
+    prompt = render_prompt(
+        template,
+        {
+            "repo_map_key_files_json": json.dumps(repo_map.get("key_files", [])),
+            "repo_map_entrypoints_json": json.dumps(repo_map.get("entrypoints", [])),
+            "files_payload": files_payload,
+        },
+    )
+    repo_model = _extract_json(
+        llm.llm_completion(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+    )
+
     check = validate_evidence(repo_root, repo_model)
     if check.ok:
         return repo_model
-    
-    # Retry with feedback about invalid quotes
-    for attempt in range(max_retries):
-        files_to_read = plan_files_to_read(llm, model=model, repo_map=repo_map, max_files_to_read=max_files_to_read)
-        file_blobs: List[Tuple[str, str]] = []
-        for rel in files_to_read:
-            abs_path = os.path.join(repo_root, rel)
-            file_blobs.append((rel, _safe_read_text(abs_path, max_chars=max_file_chars)))
-        files_payload = "\n\n".join([f"=== FILE: {p} ===\n{t}" for p, t in file_blobs if t])
-        
+
+    # Retry with feedback about invalid quotes.
+    template = load_prompt("repo_memory/prompts/infer_repo_model_retry.md")
+    for _ in range(max_retries):
         error_feedback = "\n".join(f"- {err}" for err in check.missing[:10])
-        
-        retry_prompt = f"""Your previous response had evidence quotes that don't exist in the files.
-
-ERRORS (quotes not found):
-{error_feedback}
-
-Please regenerate the repo model with CORRECT quotes.
-- Quotes must be EXACT VERBATIM substrings from the file content
-- Copy character-for-character, do NOT paraphrase
-- Use shorter quotes (function/class names) if unsure
-
-Your previous model (fix the evidence):
-{json.dumps(repo_model, indent=2)[:15000]}
-
-FILE CONTENTS (copy quotes EXACTLY from here):
-{files_payload}
-
-Return ONLY valid JSON with the same schema, but with corrected evidence quotes.
-"""
-        repo_model = _extract_json(llm.llm_completion(model=model, messages=[{"role": "user", "content": retry_prompt}]))
+        retry_prompt = render_prompt(
+            template,
+            {
+                "error_feedback": error_feedback,
+                "previous_model_json": json.dumps(repo_model, indent=2)[:15000],
+                "files_payload": files_payload,
+            },
+        )
+        repo_model = _extract_json(
+            llm.llm_completion(
+                model=model,
+                messages=[{"role": "user", "content": retry_prompt}],
+                temperature=0,
+            )
+        )
         check = validate_evidence(repo_root, repo_model)
         if check.ok:
             return repo_model
-    
-    # After all retries, return what we have (caller will validate and may raise)
+
+    # After all retries, return what we have (caller will validate and may raise).
     return repo_model
 
 
@@ -398,29 +604,20 @@ def infer_repo_model_update(
             changed_blobs.append((rel, _safe_read_text(abs_path, max_chars=max_file_chars)))
     changed_payload = "\n\n".join([f"=== FILE: {p} ===\n{t}" for p, t in changed_blobs if t])
 
-    prompt = f"""You are updating repository memory after code changes.
-
-Return ONLY valid JSON and keep it evidence-backed:
-- Preserve previous claims if still supported.
-- Update/add/remove claims as needed based on the diff and changed files.
-- Every NEW or MODIFIED claim MUST include evidence quotes from the provided changed files.
-
-Schema is identical to initial inference:
-{{
-  "summary": "...",
-  "entrypoints": [...],
-  "where_to_edit": [...],
-  "claims": [{{"kind": "...", "statement": "...", "confidence": 0.0, "evidence": [...]}}]
-}}
-
-DIFF SUMMARY:
-{diff_summary}
-
-PREVIOUS MODEL (may contain stale items):
-{json.dumps(previous_model, indent=2)[:20000]}
-
-CHANGED FILE CONTENTS (authoritative for new/updated claims):
-{changed_payload}
-"""
-    return _extract_json(llm.llm_completion(model=model, messages=[{"role": "user", "content": prompt}]))
+    template = load_prompt("repo_memory/prompts/infer_repo_model_update.md")
+    prompt = render_prompt(
+        template,
+        {
+            "diff_summary": diff_summary,
+            "previous_model_json": json.dumps(previous_model, indent=2)[:20000],
+            "changed_payload": changed_payload,
+        },
+    )
+    return _extract_json(
+        llm.llm_completion(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+    )
 

--- a/src/repo_memory/cli.py
+++ b/src/repo_memory/cli.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+RepoMemory CLI (tiny, auditable)
+===============================
+
+This CLI exists for one reason: make RepoMemory section retrieval easy and auditable
+for coding agents that can run shell commands (currently: Claude Code via the "Bash"
+tool).
+
+Why a CLI instead of an MCP tool?
+- Zero external dependencies
+- Works with the current Claude Code allowlist (Bash is already enabled)
+- The exact command invocation can be logged in `changes.log` for auditability
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+from functools import lru_cache
+import io
+import json
+import os
+import sys
+import warnings
+from typing import Any, Dict
+
+@lru_cache(maxsize=1)
+def _repo_memory_manager():
+    """
+    Import RepoMemoryManager with stdout redirected to stderr.
+
+    Why:
+    - Importing the `src` package currently triggers some import-time prints
+      (e.g., CodingAgentFactory registration).
+    - This CLI is used as a "tool" and must keep stdout clean (only the requested
+      section content), so we route any noisy import-time prints to stderr.
+    """
+    # Keep stdout clean: this CLI is used as a "tool", so stdout should contain
+    # ONLY the requested RepoMemory content (no import-time noise).
+    with contextlib.redirect_stdout(io.StringIO()):
+        with warnings.catch_warnings():
+            # Some dependency stacks emit deprecation warnings at import-time.
+            # These are not actionable for "get-section" usage and pollute output.
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            from src.repo_memory.manager import RepoMemoryManager  # local import by design
+    return RepoMemoryManager
+
+
+def _load_doc(repo_root: str) -> Dict[str, Any]:
+    """Load `.praxium/repo_memory.json` from a repo worktree and migrate to v2."""
+    RepoMemoryManager = _repo_memory_manager()
+    repo_root = os.path.abspath(repo_root)
+    path = os.path.join(repo_root, RepoMemoryManager.MEMORY_REL_PATH)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"RepoMemory file not found: {path}")
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        doc = json.load(f)
+    return RepoMemoryManager.migrate_v1_to_v2(doc)
+
+
+def cmd_get_section(args: argparse.Namespace) -> int:
+    RepoMemoryManager = _repo_memory_manager()
+    doc = _load_doc(args.repo_root)
+    text = RepoMemoryManager.get_section(doc, args.section_id, max_chars=args.max_chars)
+    sys.stdout.write(text)
+    if not text.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def cmd_list_sections(args: argparse.Namespace) -> int:
+    RepoMemoryManager = _repo_memory_manager()
+    doc = _load_doc(args.repo_root)
+    toc = RepoMemoryManager.list_sections(doc)
+    for item in toc:
+        sid = (item or {}).get("id", "")
+        title = (item or {}).get("title", "")
+        if sid:
+            sys.stdout.write(f"{sid}\t{title}\n")
+    return 0
+
+
+def cmd_summary_toc(args: argparse.Namespace) -> int:
+    RepoMemoryManager = _repo_memory_manager()
+    doc = _load_doc(args.repo_root)
+    text = RepoMemoryManager.render_summary_and_toc(doc, max_chars=args.max_chars)
+    sys.stdout.write(text)
+    if not text.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="RepoMemory CLI")
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Path to the repo root that contains `.praxium/repo_memory.json` (default: .)",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_get = sub.add_parser("get-section", help="Print one RepoMemory section by id")
+    p_get.add_argument("section_id", help="Section id (e.g., core.architecture)")
+    p_get.add_argument("--max-chars", type=int, default=8000, help="Max output chars")
+    p_get.set_defaults(func=cmd_get_section)
+
+    p_list = sub.add_parser("list-sections", help="List available section IDs (TOC)")
+    p_list.set_defaults(func=cmd_list_sections)
+
+    p_brief = sub.add_parser("summary-toc", help="Print RepoMemory Summary + TOC")
+    p_brief.add_argument("--max-chars", type=int, default=3000, help="Max output chars")
+    p_brief.set_defaults(func=cmd_summary_toc)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/repo_memory/observation.py
+++ b/src/repo_memory/observation.py
@@ -1,0 +1,119 @@
+"""
+RepoMemory observation helpers.
+
+These utilities exist to make RepoMemory behavior observable in real runs:
+- How RepoMemory changes across experiments (book stats / diffs)
+- Which RepoMemory sections the coding agent claims to have consulted
+
+Why a separate module?
+- Keep `src/repo_memory/manager.py` from growing further (it is already large).
+- Keep parsing / logging concerns out of core persistence logic.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# Section IDs are used as a stable "contract" (e.g., core.architecture, opt.payment_flow)
+_SECTION_ID_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
+
+
+def book_claim_counts(book: Dict[str, Any]) -> Dict[str, int]:
+    """
+    Return {section_id -> claim_count} for a v2 book.
+    
+    This is small and stable, so it is safe to log/store in experiment metadata.
+    """
+    sections = (book or {}).get("sections", {})
+    if not isinstance(sections, dict):
+        return {}
+    out: Dict[str, int] = {}
+    for sid, sec in sections.items():
+        claims = (sec or {}).get("claims", [])
+        out[str(sid)] = len(claims) if isinstance(claims, list) else 0
+    return out
+
+
+def book_stats(book: Dict[str, Any]) -> Dict[str, Any]:
+    """Small, log-friendly summary of a RepoMemory v2 book."""
+    summary = ((book or {}).get("summary") or "").strip()
+    toc = (book or {}).get("toc", []) or []
+    toc_ids = [str((t or {}).get("id", "")) for t in toc if (t or {}).get("id")]
+    return {
+        "summary": summary[:500],
+        "toc_ids": toc_ids,
+        "claim_counts": book_claim_counts(book),
+    }
+
+
+def diff_book_stats(before: Dict[str, Any], after: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Compute a small diff between two book snapshots.
+    
+    This is intentionally conservative:
+    - Summaries compared as strings
+    - Section changes reported as claim-count deltas
+    """
+    b = book_stats(before or {})
+    a = book_stats(after or {})
+
+    b_counts = b.get("claim_counts", {}) or {}
+    a_counts = a.get("claim_counts", {}) or {}
+
+    all_sections = sorted(set(b_counts.keys()) | set(a_counts.keys()))
+    deltas = {sid: int(a_counts.get(sid, 0)) - int(b_counts.get(sid, 0)) for sid in all_sections}
+
+    return {
+        "summary_changed": (b.get("summary") or "") != (a.get("summary") or ""),
+        "before_summary": b.get("summary"),
+        "after_summary": a.get("summary"),
+        "claim_count_deltas": deltas,
+    }
+
+
+def extract_repo_memory_sections_consulted(changes_log_text: str) -> List[str]:
+    """
+    Extract section IDs from a `changes.log` file.
+    
+    Expected format (we instruct agents to write this):
+      RepoMemory sections consulted: core.architecture, core.where_to_edit
+    Or:
+      RepoMemory sections consulted: none
+    
+    Returns:
+        Sorted unique section IDs (empty list means none or not specified).
+    """
+    text = changes_log_text or ""
+    # Find the first occurrence (case-insensitive).
+    #
+    # Agents don't always respect "put it on its own line". In practice we see cases like:
+    #   "... did X. RepoMemory sections consulted: core.architecture, core.where_to_edit"
+    # So we search for the substring anywhere in the line and parse the RHS.
+    rhs = ""
+    for raw_line in text.splitlines():
+        m = re.search(r"repomemory sections consulted:\s*(.*)$", raw_line, flags=re.IGNORECASE)
+        if m:
+            rhs = (m.group(1) or "").strip()
+            break
+    if not rhs:
+        return []
+    if rhs.lower() in ("none", "n/a", "na"):
+        return []
+
+    # Remove common wrappers: brackets, quotes.
+    rhs = rhs.strip().strip("[](){}")
+    # Split on commas or whitespace.
+    parts = re.split(r"[,\s]+", rhs)
+    ids: List[str] = []
+    for p in parts:
+        p = (p or "").strip().strip('"').strip("'")
+        if not p:
+            continue
+        if p.lower() in ("none", "n/a", "na"):
+            continue
+        if _SECTION_ID_PATTERN.match(p):
+            ids.append(p)
+    return sorted(set(ids))
+

--- a/src/repo_memory/prompts/infer_repo_model_initial.md
+++ b/src/repo_memory/prompts/infer_repo_model_initial.md
@@ -1,0 +1,117 @@
+You are inferring repository memory for an automated coding system.
+
+Return ONLY valid JSON in the **Book** format below. Every claim MUST include evidence.
+
+CRITICAL: Evidence quotes must be EXACT VERBATIM substrings that appear in the file.
+- Copy quotes character-for-character from the file content below
+- Do NOT paraphrase, summarize, or modify quotes in any way
+- The quote must exist as a continuous substring in the file
+- Shorter quotes (e.g., function signatures, class names) are safer than long ones
+
+Evidence rules (to avoid validation failures):
+- For each evidence item: `path` MUST be the file that contains the `quote`.
+- Use the exact file path shown in the FILE header (e.g., `=== FILE: main.py ===` -> path is `main.py`).
+- NEVER include the `=== FILE: ... ===` header in the quote.
+- Prefer single-line, short quotes (no newlines; ideally <120 chars).
+- IMPORTANT: Do NOT "rewrite" a quote to make it single-line.
+  - Instead, choose a shorter substring that already exists in the file.
+  - Example: prefer quoting `Accuracy as a float in [0, 1]` (verbatim) rather than inventing `Returns accuracy as a float in [0, 1]`.
+- IMPORTANT: Do NOT invent pseudo-code as evidence.
+  - Bad (usually not present verbatim): `if not data: return []`
+  - Good: quote an actual line like `if not os.path.exists(filepath):` or `return []` that exists exactly.
+- If you cannot find an exact quote that supports a claim, REMOVE the claim.
+  It is OK for sections (including core.gotchas) to be empty.
+- For multi-line code (common in configs / function calls), do NOT collapse it into a fake one-liner quote.
+  - Instead, include MULTIPLE evidence items, each quoting a real single line.
+  - Example for a LoRA config:
+    - evidence: [{"path":"main.py","quote":"r=8,"},{"path":"main.py","quote":"lora_alpha=8,"}]
+
+Required JSON schema (RepoMemory V2 format):
+{
+  "summary": "High-level what the repo does (1-2 sentences)",
+  "sections": {
+    "core.architecture": {
+      "title": "Architecture",
+      "one_liner": "System design and module structure",
+      "claims": [
+        {
+          "kind": "algorithm|architecture|contract|deployment|other",
+          "statement": "...",
+          "confidence": 0.0,
+          "evidence": [{"path": "path/in/repo.py", "quote": "EXACT verbatim substring from file"}]
+        }
+      ]
+    },
+    "core.entrypoints": {
+      "title": "Entrypoints",
+      "one_liner": "How to run the application",
+      "content": [{"path": "main.py", "how_to_run": "python main.py --help"}]
+    },
+    "core.where_to_edit": {
+      "title": "Where to edit",
+      "one_liner": "Key files for modifications",
+      "content": [{"path": "src/foo.py", "role": "core algorithm implementation"}]
+    },
+    "core.invariants": {
+      "title": "Invariants",
+      "one_liner": "Contracts, constraints, and assumptions",
+      "claims": []
+    },
+    "core.testing": {
+      "title": "Testing",
+      "one_liner": "How to run tests and validate changes",
+      "claims": []
+    },
+    "core.gotchas": {
+      "title": "Gotchas",
+      "one_liner": "Common pitfalls and sharp edges",
+      "claims": []
+    },
+    "core.dependencies": {
+      "title": "Dependencies",
+      "one_liner": "Key dependencies and environment notes",
+      "claims": []
+    },
+    "opt.<slug>": {
+      "title": "Optional Section Title",
+      "one_liner": "One line summary for TOC",
+      "claims": []
+    }
+  }
+}
+
+Rules:
+- Include at least the core.* section keys shown above (they may be empty).
+- Optional sections MUST use IDs starting with `opt.` (e.g., `opt.payment_flow`).
+- Only include `claims` in sections that need evidence-backed statements.
+
+Quality rubric (this is what makes the memory useful):
+- Your goal is NOT to list files. Your goal is to capture the repo's *meaning* so a coding agent can work quickly.
+- Prefer claims that answer:
+  - What does the repo do end-to-end? (data in -> transforms -> output)
+  - What are the key contracts? (inputs, outputs, required keys/fields, formats)
+  - What are the sharp edges? (silent fallbacks, default values, "0.0" coercions, empty behavior)
+  - How do we quickly validate changes? (how to run, what output indicates success/score)
+- Populate these sections when evidence exists in FILE CONTENTS:
+  - core.architecture: 3-6 claims describing module responsibilities + data flow.
+  - core.invariants: 2-5 claims describing input/output contracts and evaluation signals.
+  - core.gotchas: 1-4 claims describing surprising behavior and edge cases.
+  - core.testing: 1-3 claims describing how to run a sanity check or tests.
+  - core.dependencies: 1-3 claims describing notable deps / env vars / services.
+- Keep it concise: prefer ~10-25 total claims. Avoid generic trivia.
+
+Section definitions (avoid misplacing claims):
+- core.architecture: module responsibilities + data flow (NOT dependencies).
+- core.entrypoints: how to run the app/CLI (commands, scripts).
+- core.where_to_edit: key files to modify + their roles.
+- core.invariants: stable contracts (types, required keys, output formats like "SCORE:").
+- core.testing: how to validate changes (tests or a quick manual run).
+- core.gotchas: surprising behavior / edge cases (defaults, fallbacks, coercions). NOT dependencies.
+- core.dependencies: libraries/env vars/services (e.g., evidence from requirements.txt, pyproject.toml, package.json).
+
+RepoMap key files: {{repo_map_key_files_json}}
+RepoMap entrypoints: {{repo_map_entrypoints_json}}
+
+FILE CONTENTS (authoritative - copy quotes EXACTLY from here):
+{{files_payload}}
+

--- a/src/repo_memory/prompts/infer_repo_model_retry.md
+++ b/src/repo_memory/prompts/infer_repo_model_retry.md
@@ -1,0 +1,27 @@
+Your previous response had evidence quotes that don't exist in the files.
+
+ERRORS (quotes not found):
+{{error_feedback}}
+
+Please regenerate the repo model with CORRECT quotes.
+- Quotes must be EXACT VERBATIM substrings from the file content
+- Copy character-for-character, do NOT paraphrase
+- Use shorter quotes (function/class names) if unsure
+- Ensure evidence `path` matches the file the quote comes from (use the `=== FILE: ... ===` headers).
+- IMPORTANT: Do NOT "rewrite" a quote to make it shorter.
+  - Instead, select a shorter substring that already exists in the file.
+- IMPORTANT: Do NOT invent pseudo-code as evidence.
+  - Bad (usually not present verbatim): `if not data: return []`
+  - Good: quote an actual line like `if not os.path.exists(filepath):` or `return []` that exists exactly.
+- If you cannot find an exact quote that supports a claim, REMOVE the claim (do not invent).
+- For multi-line code (configs / function calls), do NOT collapse it into a fake one-liner quote.
+  - Instead, include MULTIPLE evidence items, each quoting a real single line.
+
+Your previous model (fix the evidence):
+{{previous_model_json}}
+
+FILE CONTENTS (copy quotes EXACTLY from here):
+{{files_payload}}
+
+Return ONLY valid JSON with the same schema, but with corrected evidence quotes.
+

--- a/src/repo_memory/prompts/infer_repo_model_update.md
+++ b/src/repo_memory/prompts/infer_repo_model_update.md
@@ -1,0 +1,66 @@
+You are updating repository memory after code changes.
+
+Return ONLY valid JSON in the RepoMemory V2 format and keep it evidence-backed:
+- Preserve previous sections/claims if still supported.
+- Update/add/remove claims and optional `opt.*` sections as needed based on the diff.
+- Every NEW or MODIFIED claim MUST include evidence quotes from the provided CHANGED FILE CONTENTS.
+- Unchanged claims may keep their existing evidence (even if their source file isn't in the changed set).
+
+Evidence rules (to avoid validation failures):
+- For each evidence item: `path` MUST be the file that contains the `quote`.
+- Use the exact file path shown in the CHANGED FILE header (e.g., `=== FILE: src/foo.py ===`).
+- NEVER include the `=== FILE: ... ===` header in the quote.
+- Prefer single-line, short quotes (no newlines; ideally <120 chars).
+- IMPORTANT: Do NOT "rewrite" a quote to make it single-line.
+  - Instead, choose a shorter substring that already exists in the file.
+- IMPORTANT: Do NOT invent pseudo-code as evidence.
+  - Bad (usually not present verbatim): `if not data: return []`
+  - Good: quote an actual line like `if not os.path.exists(filepath):` or `return []` that exists exactly.
+- If you cannot find an exact quote that supports a NEW/MODIFIED claim, REMOVE the claim.
+- For multi-line code (common in configs / function calls), do NOT collapse it into a fake one-liner quote.
+  - Instead, include MULTIPLE evidence items, each quoting a real single line.
+
+Schema (RepoMemory V2):
+{
+  "summary": "...",
+  "sections": {
+    "core.architecture": {"title": "...", "one_liner": "...", "claims": [...]},
+    "core.entrypoints": {"title": "...", "one_liner": "...", "content": [...]},
+    "core.where_to_edit": {"title": "...", "one_liner": "...", "content": [...]},
+    "core.invariants": {"title": "...", "one_liner": "...", "claims": [...]},
+    "core.testing": {"title": "...", "one_liner": "...", "claims": [...]},
+    "core.gotchas": {"title": "...", "one_liner": "...", "claims": [...]},
+    "core.dependencies": {"title": "...", "one_liner": "...", "claims": [...]},
+    "opt.<slug>": {"title": "...", "one_liner": "...", "claims": [...]}
+  }
+}
+
+Quality rubric (keep the memory actionable for coding agents):
+- Update the *meaning* of the repo, not just the file list.
+- If the diff changes behavior, update the relevant semantic sections:
+  - core.architecture: data flow or module responsibility changes
+  - core.invariants: input/output keys, formats, evaluation strings (e.g., "SCORE:")
+  - core.gotchas: new fallbacks, defaults, coercions, edge cases
+  - core.testing: new validation steps or tests
+  - core.dependencies: new deps / env vars / services
+- Keep it concise: avoid adding many low-value claims.
+- Every NEW or MODIFIED claim must be grounded in an EXACT quote from CHANGED FILE CONTENTS.
+
+Section definitions (avoid misplacing claims):
+- core.architecture: module responsibilities + data flow (NOT dependencies).
+- core.entrypoints: how to run the app/CLI (commands, scripts).
+- core.where_to_edit: key files to modify + their roles.
+- core.invariants: stable contracts (types, required keys, output formats like "SCORE:").
+- core.testing: how to validate changes (tests or a quick manual run).
+- core.gotchas: surprising behavior / edge cases (defaults, fallbacks, coercions). NOT dependencies.
+- core.dependencies: libraries/env vars/services (e.g., evidence from requirements.txt, pyproject.toml, package.json).
+
+DIFF SUMMARY:
+{{diff_summary}}
+
+PREVIOUS MODEL (may contain stale items):
+{{previous_model_json}}
+
+CHANGED FILE CONTENTS (authoritative for NEW/MODIFIED claims' evidence quotes):
+{{changed_payload}}
+

--- a/src/repo_memory/prompts/plan_files_to_read.md
+++ b/src/repo_memory/prompts/plan_files_to_read.md
@@ -1,0 +1,27 @@
+You are inferring a repository's architecture and algorithms.
+
+You will choose up to {{max_files_to_read}} files to read. Choose files that maximize:
+- understanding of core algorithms/ideas
+- entrypoints (how to run)
+- configuration and evaluation contracts
+
+Selection rules (high leverage for memory quality):
+- Always try to include ALL repo key files and at least one entrypoint.
+  - If there are many entrypoints, include the 1-3 most central ones (e.g., `main.py`, `cli.py`, `app.py`).
+- Include the core "business logic" modules imported or called by the entrypoint(s).
+- Include evaluation / scoring / grading contracts if present (e.g., files mentioning "SCORE", "eval", "grader", "metrics").
+- Include tests if present (e.g., `tests/`, `test_*.py`) because they often encode invariants and edge cases.
+- Prefer small, human-authored source files and docs over generated data or vendored code.
+- Avoid: lockfiles, large datasets, compiled artifacts, logs, vendored deps.
+
+You MUST return valid JSON only:
+{
+  "files_to_read": [
+    {"path": "README.md", "why": "..."}
+  ]
+}
+
+Repo key files: {{key_files_json}}
+Repo entrypoints: {{entrypoints_json}}
+Sample file list (paths): {{files_json}}
+

--- a/tests/deployment_examples/test_unified_deployment.py
+++ b/tests/deployment_examples/test_unified_deployment.py
@@ -148,9 +148,16 @@ class TestResult:
 
 
 # =============================================================================
-# Main Test Function - Following README User Flow
+# Main runner function - Following README User Flow
 # =============================================================================
-def test_repo(repo: RepoConfig, strategy: str = "local") -> TestResult:
+#
+# NOTE:
+# This module is primarily intended to be run as a script:
+#   PYTHONPATH=. python tests/deployment_examples/test_unified_deployment.py --strategy local
+#
+# We intentionally do NOT expose this as a pytest test (no `test_*` prefix)
+# because it depends on external runtime deployment capabilities.
+def run_repo(repo: RepoConfig, strategy: str = "local") -> TestResult:
     """
     Test a single repository following the README user flow:
     
@@ -344,7 +351,7 @@ def main():
     for i, repo in enumerate(repos_to_test, 1):
         info(f"[{i}/{len(repos_to_test)}] Testing {repo.name}...")
         
-        result = test_repo(repo, strategy=args.strategy)
+        result = run_repo(repo, strategy=args.strategy)
         results.append(result)
         
         print()

--- a/tests/test_expert_flow.py
+++ b/tests/test_expert_flow.py
@@ -121,16 +121,16 @@ def test_workflow_retrieval_quality():
         print(f"\n  Goal: {goal}")
         knowledge = retriever.retrieve_knowledge(goal)
         print(f"  Tier: {knowledge.tier.value}")
-
+        
         if knowledge.workflow:
             wf = knowledge.workflow
             print(f"  Workflow: {wf.title}")
             print(f"  Steps: {len(wf.steps)}")
-
+            
             # Check quality metrics
             has_heuristics = any(s.principle.heuristics for s in wf.steps) or bool(wf.heuristics)
             print(f"  Has heuristics: {has_heuristics}")
-
+            
             for i, step in enumerate(wf.steps, 1):
                 h_count = len(step.principle.heuristics)
                 print(f"    Step {i}: {step.principle.title} ({h_count} heuristics)")

--- a/tests/test_prompt_externalization.py
+++ b/tests/test_prompt_externalization.py
@@ -1,0 +1,38 @@
+"""
+Prompt externalization smoke tests
+=================================
+
+These tests ensure that the prompt templates we rely on are:
+- present on disk
+- loadable via `src.core.prompt_loader.load_prompt`
+
+This is important because prompt tuning is a first-class requirement for RepoMemory.
+"""
+
+from __future__ import annotations
+
+from src.core import prompt_loader
+
+
+PROMPT_PATHS = [
+    # RepoMemory builders
+    "repo_memory/prompts/plan_files_to_read.md",
+    "repo_memory/prompts/infer_repo_model_initial.md",
+    "repo_memory/prompts/infer_repo_model_retry.md",
+    "repo_memory/prompts/infer_repo_model_update.md",
+    # Execution prompts (coding + ideation)
+    "execution/prompts/coding_agent_implement.md",
+    "execution/prompts/coding_agent_debug.md",
+    "execution/prompts/ideation_solution_react.md",
+]
+
+
+def test_prompt_files_exist_and_load():
+    # Clear cache to ensure we actually read from disk in this test.
+    prompt_loader.load_prompt.cache_clear()
+
+    for path in PROMPT_PATHS:
+        text = prompt_loader.load_prompt(path)
+        assert isinstance(text, str)
+        assert len(text.strip()) > 20, f"Prompt seems empty: {path}"
+

--- a/tests/test_repo_map_git_consistency.py
+++ b/tests/test_repo_map_git_consistency.py
@@ -1,0 +1,65 @@
+"""
+RepoMap integration test (portable + git-consistent).
+
+This test is intentionally small and fast. It does NOT call any LLMs.
+
+We validate that the deterministic RepoMap builder:
+- Stores a portable `repo_root` (".", not absolute /tmp/... paths)
+- Excludes infrastructure/meta paths even if they exist in git:
+  - `.praxium/*` (RepoMemory storage)
+  - `sessions/*` (nested experiment clones)
+  - `changes.log` (observability/audit metadata)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import git
+
+from src.repo_memory.builders import build_repo_map
+
+
+def test_build_repo_map_git_filters_meta_paths(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = git.Repo.init(repo_dir)
+
+    # "Real" code file
+    (repo_dir / "main.py").write_text("print('hello')\n")
+
+    # Dotfile (should not be mangled to "gitignore")
+    (repo_dir / ".gitignore").write_text("*.log\n")
+
+    # Observability metadata (must be excluded from repo structure map)
+    (repo_dir / "changes.log").write_text("RepoMemory sections consulted: none\n")
+
+    # RepoMemory storage (must be excluded)
+    prax = repo_dir / ".praxium"
+    prax.mkdir()
+    (prax / "repo_memory.json").write_text(json.dumps({"schema_version": 2}, indent=2))
+
+    # Nested experiment clone (must be excluded)
+    sess = repo_dir / "sessions" / "experiment_0"
+    sess.mkdir(parents=True)
+    (sess / "junk.txt").write_text("x\n")
+
+    # Commit everything (even meta paths) to ensure filtering is robust.
+    repo.git.add("-A")
+    repo.git.commit("-m", "init")
+
+    repo_map = build_repo_map(str(repo_dir))
+    assert repo_map.get("repo_root") == "."
+
+    files = repo_map.get("files", []) or []
+    assert "main.py" in files
+    assert ".gitignore" in files
+    assert "gitignore" not in files  # ensure we don't strip leading '.'
+
+    # Meta exclusions
+    assert "changes.log" not in files
+    assert not any(p.startswith(".praxium/") for p in files)
+    assert "praxium/repo_memory.json" not in files  # guard against dot-stripping regressions
+    assert not any(p.startswith("sessions/") for p in files)
+

--- a/tests/test_repo_memory_book.py
+++ b/tests/test_repo_memory_book.py
@@ -1,0 +1,141 @@
+"""
+Unit tests for RepoMemory "Book" (schema v2) behavior.
+
+These tests are intentionally lightweight:
+- No real LLM calls
+- No Neo4j/Weaviate dependencies
+- Focus on migration, TOC rendering, section access, and evidence validation
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+import pytest
+
+from src.repo_memory import RepoMemoryManager
+from src.repo_memory.builders import validate_evidence
+
+
+def test_migrate_v1_to_v2_preserves_data() -> None:
+    v1_doc = {
+        "schema_version": 1,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "repo_model": {
+            "summary": "Test summary",
+            "entrypoints": [{"path": "main.py", "how_to_run": "python main.py"}],
+            "where_to_edit": [{"path": "src/core.py", "role": "core logic"}],
+            "claims": [
+                {
+                    "kind": "architecture",
+                    "statement": "Uses layered architecture",
+                    "confidence": 0.9,
+                    "evidence": [{"path": "README.md", "quote": "Architecture"}],
+                }
+            ],
+        },
+        "quality": {"evidence_ok": True, "missing_evidence": [], "claim_count": 1},
+    }
+
+    v2_doc = RepoMemoryManager.migrate_v1_to_v2(dict(v1_doc))
+    assert v2_doc["schema_version"] == 2
+    assert "book" in v2_doc
+    assert v2_doc["book"]["summary"] == "Test summary"
+
+    sections = v2_doc["book"]["sections"]
+    assert sections["core.entrypoints"]["content"] == v1_doc["repo_model"]["entrypoints"]
+    assert sections["core.where_to_edit"]["content"] == v1_doc["repo_model"]["where_to_edit"]
+
+
+def test_migrate_v1_to_v2_idempotent() -> None:
+    v1_doc = {"schema_version": 1, "repo_model": {"summary": "x", "claims": []}}
+    once = RepoMemoryManager.migrate_v1_to_v2(dict(v1_doc))
+    twice = RepoMemoryManager.migrate_v1_to_v2(dict(once))
+    assert twice == once
+
+
+def test_render_summary_and_toc_bounded() -> None:
+    doc = RepoMemoryManager.migrate_v1_to_v2({"schema_version": 1, "repo_model": {"summary": "x", "claims": []}})
+    out = RepoMemoryManager.render_summary_and_toc(doc, max_chars=120)
+    assert len(out) <= 120
+
+
+def test_render_summary_and_toc_format() -> None:
+    doc = RepoMemoryManager.migrate_v1_to_v2({"schema_version": 1, "repo_model": {"summary": "x", "claims": []}})
+    out = RepoMemoryManager.render_summary_and_toc(doc, max_chars=2000)
+    assert "## Summary" in out
+    assert "## Table of Contents" in out
+    assert "core.architecture" in out
+
+
+def test_get_section_found_renders_claims() -> None:
+    doc = {
+        "schema_version": 2,
+        "book": {
+            "summary": "x",
+            "sections": {
+                "core.architecture": {
+                    "title": "Architecture",
+                    "one_liner": "Design",
+                    "claims": [
+                        {
+                            "kind": "architecture",
+                            "statement": "Uses plugins",
+                            "evidence": [{"path": "foo.py", "quote": "class Plugin"}],
+                        }
+                    ],
+                }
+            },
+        },
+    }
+    out = RepoMemoryManager.get_section(doc, "core.architecture", max_chars=2000)
+    assert "Uses plugins" in out
+    assert "evidence:" in out
+
+
+def test_get_section_not_found() -> None:
+    doc = RepoMemoryManager.migrate_v1_to_v2({"schema_version": 1, "repo_model": {"summary": "x", "claims": []}})
+    out = RepoMemoryManager.get_section(doc, "does.not.exist", max_chars=500)
+    assert "not found" in out.lower()
+
+
+def test_list_sections_returns_toc_metadata() -> None:
+    doc = RepoMemoryManager.migrate_v1_to_v2({"schema_version": 1, "repo_model": {"summary": "x", "claims": []}})
+    toc = RepoMemoryManager.list_sections(doc)
+    assert isinstance(toc, list)
+    assert any(item.get("id") == "core.architecture" for item in toc)
+
+
+def test_evidence_validation_v2() -> None:
+    # Create a tiny repo in a temp dir.
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "foo.py").write_text("class Plugin:\n    pass\n")
+        model_v2 = {
+            "summary": "x",
+            "sections": {
+                "core.architecture": {
+                    "title": "Architecture",
+                    "one_liner": "Design",
+                    "claims": [
+                        {
+                            "kind": "architecture",
+                            "statement": "Has Plugin class",
+                            "evidence": [{"path": "foo.py", "quote": "class Plugin:"}],
+                        }
+                    ],
+                }
+            },
+        }
+        check = validate_evidence(tmp, model_v2)
+        assert check.ok
+
+
+#
+# NOTE:
+# We intentionally do NOT test `infer_repo_model_initial()` here because it calls a real LLM.
+# Real LLM coverage lives in `tests/test_repo_memory.py`.
+

--- a/tests/test_repo_memory_book_integration.py
+++ b/tests/test_repo_memory_book_integration.py
@@ -1,0 +1,66 @@
+"""
+Integration tests for RepoMemory Book (schema v2).
+
+These tests validate behavior across:
+- Disk persistence (v1 file upgraded on disk so coding agents can read Book/TOC)
+- Git branch loading (read memory from a branch without checkout)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import git
+
+from src.repo_memory import RepoMemoryManager
+
+
+def test_ensure_exists_in_worktree_persists_v1_to_v2_migration(tmp_path: Path) -> None:
+    # Write a v1 memory file to disk.
+    prax = tmp_path / ".praxium"
+    prax.mkdir()
+    memory_path = prax / "repo_memory.json"
+    v1 = {
+        "schema_version": 1,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "repo_model": {
+            "summary": "My repo",
+            "entrypoints": [{"path": "main.py", "how_to_run": "python main.py"}],
+            "where_to_edit": [{"path": "foo.py", "role": "core"}],
+            "claims": [],
+        },
+        "experiments": [],
+        "quality": {"evidence_ok": False, "missing_evidence": [], "claim_count": 0},
+    }
+    memory_path.write_text(json.dumps(v1, indent=2))
+
+    # ensure_exists should upgrade the file on disk (so agents can read Book/TOC).
+    doc = RepoMemoryManager.ensure_exists_in_worktree(str(tmp_path))
+    assert doc.get("schema_version") == 2
+    assert "book" in doc
+
+    reloaded = json.loads(memory_path.read_text())
+    assert reloaded.get("schema_version") == 2
+    assert "book" in reloaded
+    assert "sections" in reloaded["book"]
+
+
+def test_load_from_git_branch_migrates_v1_doc(tmp_path: Path) -> None:
+    repo = git.Repo.init(tmp_path)
+    (tmp_path / "README.md").write_text("# Repo\n")
+
+    prax = tmp_path / ".praxium"
+    prax.mkdir()
+    (prax / "repo_memory.json").write_text(
+        json.dumps({"schema_version": 1, "repo_model": {"summary": "x", "claims": []}}, indent=2)
+    )
+
+    repo.git.add("-A")
+    repo.git.commit("-m", "init with v1 memory")
+
+    doc = RepoMemoryManager.load_from_git_branch(repo, repo.active_branch.name)
+    assert doc is not None
+    assert doc.get("schema_version") == 2
+    assert "book" in doc
+

--- a/tests/test_repo_memory_cli_standalone.py
+++ b/tests/test_repo_memory_cli_standalone.py
@@ -1,0 +1,68 @@
+"""
+RepoMemory CLI (standalone) tests
+================================
+
+We expose RepoMemory sections to coding agents via a tiny CLI:
+`tools/repo_memory_cli.py`.
+
+These tests validate:
+- the CLI runs without importing `src` (no noisy stdout side effects)
+- it can render a single section by ID from a synthetic repo_memory.json
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_repo_memory_cli_get_section(tmp_path: Path):
+    repo_root = tmp_path / "repo"
+    praxium_dir = repo_root / ".praxium"
+    praxium_dir.mkdir(parents=True)
+
+    (repo_root / "README.md").write_text("hello\n")
+
+    doc = {
+        "schema_version": 2,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "book": {
+            "summary": "Test repo",
+            "toc": [{"id": "core.architecture", "title": "Architecture", "one_liner": "Test"}],
+            "sections": {
+                "core.architecture": {
+                    "title": "Architecture",
+                    "one_liner": "Test",
+                    "claims": [
+                        {
+                            "kind": "architecture",
+                            "statement": "Has a README",
+                            "confidence": 1.0,
+                            "evidence": [{"path": "README.md", "quote": "hello"}],
+                        }
+                    ],
+                }
+            },
+        },
+    }
+    (praxium_dir / "repo_memory.json").write_text(json.dumps(doc))
+
+    cli_path = Path(__file__).resolve().parents[1] / "tools" / "repo_memory_cli.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(cli_path),
+            "--repo-root",
+            str(repo_root),
+            "get-section",
+            "core.architecture",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Architecture" in result.stdout
+    assert "Has a README" in result.stdout
+

--- a/tests/test_repo_memory_latest_commit_semantics.py
+++ b/tests/test_repo_memory_latest_commit_semantics.py
@@ -1,0 +1,100 @@
+"""
+Latest-commit semantics for RepoMemory updates
+=============================================
+
+We want `.praxium/repo_memory.json` to reflect a *committed* code state, not a dirty
+worktree. The engine now schedules RepoMemory updates to run inside
+`ExperimentSession.close_session()` after final commits and before push/cleanup.
+
+This test asserts the resulting git history shape:
+- The branch HEAD commit message is the RepoMemory metadata commit
+- The recorded `head_commit` / `code_head_commit` inside RepoMemory matches the
+  parent commit of the memory commit (the last code/data commit)
+
+NOTE: This test uses real LLM calls via `LLMBackend()` and costs money.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import git
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from src.core.llm import LLMBackend
+from src.execution.coding_agents.base import CodingAgentConfig
+from src.execution.experiment_workspace.experiment_workspace import ExperimentWorkspace
+from src.repo_memory import RepoMemoryManager
+
+
+def test_repo_memory_update_runs_after_final_commit(tmp_path: Path):
+    llm = LLMBackend()
+
+    # Use an agent adapter that can initialize without external deps/keys.
+    agent_cfg = CodingAgentConfig(
+        agent_type="openhands",
+        model="gpt-4.1-mini",
+        debug_model="gpt-4.1-mini",
+        agent_specific={},
+    )
+
+    workspace_dir = tmp_path / "ws"
+    workspace = ExperimentWorkspace(
+        coding_agent_config=agent_cfg,
+        workspace_dir=str(workspace_dir),
+    )
+
+    # Seed a minimal codebase on main.
+    (workspace_dir / "README.md").write_text("Hello RepoMemory\n")
+    workspace.repo.git.add(["README.md"])
+    workspace.repo.git.commit("-m", "feat: add README")
+
+    # Ensure baseline memory exists and is committed on main so experiment branches inherit it.
+    RepoMemoryManager.ensure_exists_in_worktree(str(workspace_dir))
+    workspace.repo.git.add([RepoMemoryManager.MEMORY_REL_PATH])
+    if workspace.repo.is_dirty(untracked_files=True):
+        workspace.repo.git.commit("-m", "chore(praxium): add baseline repo memory")
+
+    branch_name = "exp_latest_commit_semantics"
+    session = workspace.create_experiment_session(branch_name=branch_name, parent_branch_name="main", llm=llm)
+
+    # Make a committed code change (simulates agent commits).
+    Path(session.session_folder, "main.py").write_text("print('hi')\n")
+    session.repo.git.add(["main.py"])
+    session.repo.git.commit("-m", "feat: add main.py")
+
+    # Create run output (committed by close_session via commit_folder).
+    Path(session.run_dir, "result.txt").write_text("ok\n")
+
+    # Create an uncommitted changes.log (committed by close_session final commit).
+    Path(session.session_folder, "changes.log").write_text("RepoMemory sections consulted: none\n")
+
+    # Schedule memory update (it will run during close_session after the commits above).
+    session.schedule_repo_memory_update(
+        solution_spec="Add a main.py entrypoint",
+        run_result={"score": 1.0, "run_had_error": False},
+    )
+
+    # Finalize: commits + RepoMemory update + push back to workspace repo.
+    workspace.finalize_session(session)
+
+    # Inspect the resulting branch in the workspace repo.
+    head = workspace.repo.commit(branch_name)
+    assert "update repo memory" in head.message.lower()
+
+    doc_raw = workspace.repo.git.show(f"{branch_name}:{RepoMemoryManager.MEMORY_REL_PATH}")
+    doc = json.loads(doc_raw)
+    experiments = doc.get("experiments", []) or []
+    assert experiments, "Expected at least one experiment recorded in RepoMemory"
+
+    last = experiments[-1] or {}
+    assert last.get("branch") == branch_name
+
+    # The code state this memory describes should be the parent commit of the memory commit.
+    parent_sha = head.parents[0].hexsha if head.parents else ""
+    assert last.get("head_commit") == parent_sha
+    assert last.get("code_head_commit") == parent_sha
+

--- a/tests/test_repo_memory_react_loop.py
+++ b/tests/test_repo_memory_react_loop.py
@@ -1,0 +1,75 @@
+"""
+RepoMemory ideation ReAct loop tests
+===================================
+
+We keep these tests lightweight and focused:
+- Parsing robustness for the strict JSON protocol
+- An integration-style smoke test that runs the loop on a tiny repo
+
+NOTE: The integration test uses a real LLM call via `LLMBackend()` and costs money.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import git
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from src.core.llm import LLMBackend
+from src.execution.ideation.repo_memory_react import _extract_json_obj, ideate_solution_with_repo_memory_react
+
+
+def test_extract_json_obj_strict():
+    assert _extract_json_obj('{"action":"final","solution":"ok"}') == {
+        "action": "final",
+        "solution": "ok",
+    }
+
+
+def test_extract_json_obj_fallback_block():
+    text = "noise\n\n{\"action\":\"get_section\",\"section_id\":\"core.architecture\"}\n\nnoise"
+    assert _extract_json_obj(text) == {"action": "get_section", "section_id": "core.architecture"}
+
+
+def test_ideation_react_loop_smoke(tmp_path: Path):
+    # Minimal git repo with a committed RepoMemory file on main.
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = git.Repo.init(repo_dir)
+
+    (repo_dir / ".praxium").mkdir()
+    doc = {
+        "schema_version": 2,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "book": {
+            "summary": "Test repo for ideation loop",
+            "toc": [{"id": "core.architecture", "title": "Architecture", "one_liner": "Test"}],
+            "sections": {
+                "core.architecture": {"title": "Architecture", "one_liner": "Test", "claims": []}
+            },
+        },
+        "experiments": [],
+    }
+    (repo_dir / ".praxium" / "repo_memory.json").write_text(json.dumps(doc))
+    repo.git.add([".praxium/repo_memory.json"])
+    repo.git.commit("-m", "chore: add repo memory")
+
+    llm = LLMBackend()
+    solution, sections = ideate_solution_with_repo_memory_react(
+        llm=llm,
+        model="gpt-4.1-mini",
+        repo=repo,
+        base_branch="master" if "master" in [h.name for h in repo.heads] else "main",
+        problem="Return a very short solution that says 'OK'.",
+        output_requirements="Return {\"action\":\"final\",\"solution\":\"OK\"}. Do not call get_section.",
+        max_rounds=2,
+    )
+
+    assert isinstance(solution, str)
+    assert len(solution.strip()) > 0
+    assert isinstance(sections, list)
+

--- a/tools/repo_memory_cli.py
+++ b/tools/repo_memory_cli.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+RepoMemory CLI (standalone; no `import src`)
+==========================================
+
+This file is intentionally **not** inside the `src/` package.
+
+Why:
+- `python -m src.<...>` imports `src/__init__.py`, which today triggers heavy imports,
+  agent registration prints, and warnings.
+- Coding agents use this command as a "tool", so stdout must stay clean and only
+  contain the requested RepoMemory content.
+
+This script is the simplest reliable approach: read `.praxium/repo_memory.json`
+directly and render sections without importing Praxium internals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, List, Tuple
+
+
+def _load_doc(repo_root: str) -> Dict[str, Any]:
+    repo_root = os.path.abspath(repo_root)
+    path = os.path.join(repo_root, ".praxium", "repo_memory.json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"RepoMemory file not found: {path}")
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return json.load(f)
+
+
+def _ensure_book_v2(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Best-effort migration to a v2 "book" view.
+
+    In Praxium today, `.praxium/repo_memory.json` should already contain `book`.
+    This is only a safety net for older v1 documents.
+    """
+    doc = doc or {}
+    if isinstance(doc.get("book"), dict) and isinstance((doc.get("book") or {}).get("sections"), dict):
+        return doc
+
+    # Minimal derivation from v1-ish fields
+    repo_model = doc.get("repo_model", {}) if isinstance(doc.get("repo_model"), dict) else {}
+    summary = (repo_model.get("summary") or "").strip()
+    claims = repo_model.get("claims", []) if isinstance(repo_model.get("claims"), list) else []
+    entrypoints = repo_model.get("entrypoints", []) if isinstance(repo_model.get("entrypoints"), list) else []
+    where = repo_model.get("where_to_edit", []) if isinstance(repo_model.get("where_to_edit"), list) else []
+
+    sections: Dict[str, Any] = {
+        "core.architecture": {
+            "title": "Architecture",
+            "one_liner": "System design and module structure",
+            "claims": claims,
+        },
+        "core.entrypoints": {
+            "title": "Entrypoints",
+            "one_liner": "How to run the application",
+            "content": entrypoints,
+        },
+        "core.where_to_edit": {
+            "title": "Where to edit",
+            "one_liner": "Key files for modifications",
+            "content": where,
+        },
+    }
+
+    toc = _build_toc(sections)
+    doc["book"] = {"summary": summary, "sections": sections, "toc": toc}
+    return doc
+
+
+def _build_toc(sections: Dict[str, Any]) -> List[Dict[str, str]]:
+    toc: List[Dict[str, str]] = []
+    for sid in sorted((sections or {}).keys()):
+        sec = (sections or {}).get(sid, {}) or {}
+        toc.append(
+            {
+                "id": sid,
+                "title": str(sec.get("title") or sid),
+                "one_liner": str(sec.get("one_liner") or ""),
+            }
+        )
+    return toc
+
+
+def _render_summary_toc(doc: Dict[str, Any], max_chars: int) -> str:
+    doc = _ensure_book_v2(doc)
+    book = doc.get("book", {}) or {}
+    summary = (book.get("summary") or "").strip() or "(missing)"
+    toc = book.get("toc") or _build_toc(book.get("sections", {}) or {})
+
+    lines = [
+        "# Repo Memory (book)",
+        f"Schema: v{doc.get('schema_version')}",
+        f"GeneratedAt: {doc.get('generated_at')}",
+        "",
+        "## Summary",
+        summary,
+        "",
+        "## Table of Contents (section IDs)",
+    ]
+    for item in toc:
+        sid = (item or {}).get("id", "")
+        title = (item or {}).get("title", "")
+        one = (item or {}).get("one_liner", "")
+        if sid:
+            suffix = f": {one}" if one else ""
+            lines.append(f"- [{sid}] {title}{suffix}")
+    lines.extend(
+        [
+            "",
+            "## How to read details",
+            "- Open `.praxium/repo_memory.json`",
+            "- Find `book.sections[section_id]` from the TOC above",
+        ]
+    )
+    text = "\n".join(lines)
+    return text[:max_chars] if len(text) > max_chars else text
+
+
+def _render_section(doc: Dict[str, Any], section_id: str, max_chars: int) -> str:
+    doc = _ensure_book_v2(doc)
+    sections = ((doc.get("book") or {}).get("sections") or {}) if isinstance((doc.get("book") or {}).get("sections"), dict) else {}
+    if section_id not in sections:
+        available = list(sections.keys())
+        msg = f"Section '{section_id}' not found. Available: {available}"
+        return msg[:max_chars]
+
+    sec = sections.get(section_id, {}) or {}
+    title = str(sec.get("title") or section_id)
+    one_liner = str(sec.get("one_liner") or "")
+
+    # Claims-style section
+    claims = sec.get("claims", None)
+    if isinstance(claims, list):
+        out: List[str] = [f"# {title}", ""]
+        if one_liner:
+            out.extend([one_liner, ""])
+        for claim in claims:
+            kind = (claim or {}).get("kind", "?")
+            stmt = (claim or {}).get("statement", "")
+            out.append(f"- [{kind}] {stmt}")
+            for ev in (claim or {}).get("evidence", []) or []:
+                path = (ev or {}).get("path", "?")
+                quote = (ev or {}).get("quote", "")
+                quote_short = quote if len(quote) <= 200 else quote[:200] + "...(truncated)"
+                out.append(f'  - evidence: {path}: "{quote_short}"')
+        text = "\n".join(out)
+        return text[:max_chars]
+
+    # Content-style section
+    content = sec.get("content", None)
+    if content is not None:
+        text = json.dumps(content, indent=2, ensure_ascii=False)
+        return text[:max_chars]
+
+    return f"(empty section: {section_id})"[:max_chars]
+
+
+def _cmd_get_section(args: argparse.Namespace) -> int:
+    doc = _load_doc(args.repo_root)
+    sys.stdout.write(_render_section(doc, args.section_id, args.max_chars) + "\n")
+    return 0
+
+
+def _cmd_list_sections(args: argparse.Namespace) -> int:
+    doc = _ensure_book_v2(_load_doc(args.repo_root))
+    toc = (doc.get("book") or {}).get("toc") or _build_toc((doc.get("book") or {}).get("sections") or {})
+    for item in toc:
+        sid = (item or {}).get("id", "")
+        title = (item or {}).get("title", "")
+        if sid:
+            sys.stdout.write(f"{sid}\t{title}\n")
+    return 0
+
+
+def _cmd_summary_toc(args: argparse.Namespace) -> int:
+    doc = _load_doc(args.repo_root)
+    sys.stdout.write(_render_summary_toc(doc, args.max_chars) + "\n")
+    return 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="RepoMemory CLI (standalone)")
+    parser.add_argument("--repo-root", default=".", help="Repo root (default: .)")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_get = sub.add_parser("get-section", help="Print one section by id")
+    p_get.add_argument("section_id", help="Section id (e.g., core.architecture)")
+    p_get.add_argument("--max-chars", type=int, default=8000, help="Max output chars")
+    p_get.set_defaults(func=_cmd_get_section)
+
+    p_list = sub.add_parser("list-sections", help="List available section IDs (TOC)")
+    p_list.set_defaults(func=_cmd_list_sections)
+
+    p_toc = sub.add_parser("summary-toc", help="Print Summary + TOC")
+    p_toc.add_argument("--max-chars", type=int, default=3000, help="Max output chars")
+    p_toc.set_defaults(func=_cmd_summary_toc)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## High-level goals

- Make RepoMemory **portable** and **git-consistent** (no absolute paths, no ignored/transient files in RepoMap).
- Make RepoMemory **auditable** (commit `changes.log`; persist which sections were consulted).
- Ensure RepoMemory reflects the repo's **latest committed state** (“latest commit semantics”).
- Externalize prompts so we can **tune them without code changes**.
- Add **engine-mediated** “ReAct-style” section retrieval for ideation, and a CLI tool for coding-agent section access (Claude Code).


See the full PR notes here:
developer_docs/pr_repo_memory_pr_notes.md