### PR TITLE
Add F1 Score Evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ kapso.learn(
 solution = kapso.evolve(
     goal="Fine-tune Llama-3.1-8B for legal contract risk classification using DPO alignment, target F1 > 0.85 on high-risk clause detection",
     output_path="./models/legal_risk_v1",
-    evaluator="regex_pattern",
-    evaluator_params={"pattern": r"F1: ([\d.]+)"},
+    evaluator="f1_score",
     stop_condition="threshold",
     stop_condition_params={"threshold": 0.85},
     context=[

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,8 +40,7 @@ kapso.learn(
 solution = kapso.evolve(
     goal="Fine-tune Llama-3.1-8B for legal contract risk classification using DPO alignment, target F1 > 0.85 on high-risk clause detection",
     output_path="./models/legal_risk_v1",
-    evaluator="regex_pattern",
-    evaluator_params={"pattern": r"F1: ([\d.]+)"},
+    evaluator="f1_score",
     stop_condition="threshold",
     stop_condition_params={"threshold": 0.85},
     context=[


### PR DESCRIPTION
### Summary
- Add built-in `f1_score` evaluator for simpler ML experiment evaluation
- Simplify usage from `evaluator="regex_pattern", evaluator_params={"pattern": r"F1: ([\d.]+)"}` to just `evaluator="f1_score"`
- Update README and docs examples to use the new evaluator

### Features
The `f1_score` evaluator auto-detects F1 scores from multiple common formats:
- Stdout patterns: `F1: 0.85`, `f1_score: 0.85`, `F1=85%`
- JSON output: `{"f1": 0.85}`, `{"f1_score": 0.85}`
- JSON files: reads from `results.json` by default