### PR TITLE
Rename DeepWebResearch to Researcher and externalize prompt

### DIFF
--- a/docs/evolve/architecture.mdx
+++ b/docs/evolve/architecture.mdx
@@ -222,7 +222,7 @@ src/
 │   │       └── research_ingestor.py
 │   │
 │   ├── web_research/        # Deep web research
-│   │   ├── deep_web_research.py
+│   │   ├── researcher.py
 │   │   └── prompts/
 │   │
 │   └── wiki_structure/      # Wiki page definitions

--- a/docs/research/overview.mdx
+++ b/docs/research/overview.mdx
@@ -17,8 +17,8 @@ The research system uses OpenAI's `web_search` tool with reasoning capabilities 
 ```mermaid
 flowchart LR
     subgraph Research["Web Research"]
-        O[Objective] --> DWR[DeepWebResearch]
-        DWR --> WS[web_search tool]
+        O[Objective] --> R[Researcher]
+        R --> WS[web_search tool]
         WS --> S1[Source 1]
         WS --> S2[Source 2]
         WS --> S3[Source N]

--- a/src/kapso.py
+++ b/src/kapso.py
@@ -29,7 +29,7 @@ from src.environment.handlers.generic import GenericProblemHandler
 from src.knowledge.search import KnowledgeSearchFactory, KGIndexInput
 from src.knowledge.search.base import KGIndexMetadata
 from src.knowledge.learners import Source, KnowledgePipeline
-from src.knowledge.web_research import DeepWebResearch, ResearchDepth, ResearchMode, ResearchFindings
+from src.knowledge.web_research import Researcher, ResearchDepth, ResearchMode, ResearchFindings
 from src.core.config import load_config
 
 # Placeholder types for unimplemented learning
@@ -145,7 +145,7 @@ class Kapso:
             print(f"Initialized Kapso (Knowledge Graph: disabled)")
 
         # Lazy-initialized web researcher (created on first `.research()` call).
-        self._web_researcher: Optional[DeepWebResearch] = None
+        self._web_researcher: Optional[Researcher] = None
     
     # =========================================================================
     # Knowledge Graph Indexing
@@ -344,7 +344,7 @@ class Kapso:
             - .source -> Source.Research for direct KG ingestion
         """
         if self._web_researcher is None:
-            self._web_researcher = DeepWebResearch()
+            self._web_researcher = Researcher()
 
         return self._web_researcher.research(objective, mode=mode, depth=depth)
     

--- a/src/knowledge/web_research/__init__.py
+++ b/src/knowledge/web_research/__init__.py
@@ -4,13 +4,13 @@
 # `ResearchFindings` objects with fluent accessors.
 #
 # Exports:
-# - DeepWebResearch: main entry point (OpenAI Responses API + web_search tool)
+# - Researcher: main entry point (OpenAI Responses API + web_search tool)
 # - ResearchFindings: wrapper with .repos() and .ideas() methods
 # - ResearchMode: "idea" | "implementation" | "both"
 # - ResearchDepth: "light" | "deep"
 
-from src.knowledge.web_research.deep_web_research import DeepWebResearch, ResearchDepth, ResearchMode
+from src.knowledge.web_research.researcher import Researcher, ResearchDepth, ResearchMode
 from src.knowledge.web_research.research_findings import ResearchFindings
 
-__all__ = ["DeepWebResearch", "ResearchFindings", "ResearchDepth", "ResearchMode"]
+__all__ = ["Researcher", "ResearchFindings", "ResearchDepth", "ResearchMode"]
 

--- a/src/knowledge/web_research/prompts/research_envelope.md
+++ b/src/knowledge/web_research/prompts/research_envelope.md
@@ -1,0 +1,24 @@
+You are a senior engineer-researcher.
+
+Task: Do deep public web research for the following objective:
+
+OBJECTIVE: {objective}
+
+Use the web_search tool. Perform multiple searches and read multiple sources.
+Prioritize authoritative sources (official docs, standards, major vendors, reputable blogs, papers).
+
+Output: a single Markdown report (see mode instructions for the exact structure).
+
+Final output formatting (MANDATORY):
+- Wrap the entire report in `<research_result>` and `</research_result>` tags.
+- Do NOT include any text outside those tags.
+
+Citation rules (CRITICAL):
+- For any non-trivial claim, include an inline URL in parentheses right after the claim.
+- Use FULL raw URLs like `(https://example.com/...)`. Do not use placeholder links like `[source](#cite)` or footnote-only citations.
+- If you use Markdown links, also include the raw URL somewhere obvious (preferably in parentheses).
+- Do NOT invent citations. If you cannot find a good source, say so explicitly.
+
+Mode: {mode}
+
+{mode_instructions}


### PR DESCRIPTION
## Summary
- Rename `DeepWebResearch` class to `Researcher` for simplicity
- Rename `deep_web_research.py` to `researcher.py`
- Extract research prompt envelope to external markdown file (`prompts/research_envelope.md`)

## Test plan
- [x] Verify imports work: `from src.knowledge.web_research import Researcher`
- [x] Run existing tests that use the research module