### PR TITLE
Fix Codex coding-agent CLI choice

### DIFF
--- a/src/kapso/cli.py
+++ b/src/kapso/cli.py
@@ -46,7 +46,7 @@ from kapso.researcher import ResearchMode, ResearchDepth
 
 
 # Available coding agents
-AVAILABLE_AGENTS = ["aider", "gemini", "claude_code", "openhands"]
+AVAILABLE_AGENTS = ["aider", "gemini", "claude_code", "codex", "openhands"]
 
 # Available deploy strategies
 DEPLOY_STRATEGIES = ["auto", "local", "docker", "modal", "bentoml", "langgraph"]

--- a/src/kapso/cli.py
+++ b/src/kapso/cli.py
@@ -46,7 +46,7 @@ from kapso.researcher import ResearchMode, ResearchDepth
 
 
 # Available coding agents
-AVAILABLE_AGENTS = ["aider", "gemini", "claude_code", "codex", "openhands"]
+AVAILABLE_AGENTS = CodingAgentFactory.list_available()
 
 # Available deploy strategies
 DEPLOY_STRATEGIES = ["auto", "local", "docker", "modal", "bentoml", "langgraph"]

--- a/tests/test_cli_agent_choices.py
+++ b/tests/test_cli_agent_choices.py
@@ -4,7 +4,6 @@ from kapso.cli import AVAILABLE_AGENTS
 from kapso.execution.coding_agents.factory import CodingAgentFactory
 
 
-def test_codex_is_available_to_cli_and_factory():
-    """The CLI must accept every shipped, registered Codex adapter."""
-    assert "codex" in AVAILABLE_AGENTS
-    assert CodingAgentFactory.is_available("codex")
+def test_cli_agent_choices_match_factory_registry():
+    """The CLI must expose every coding agent registered by the factory."""
+    assert AVAILABLE_AGENTS == CodingAgentFactory.list_available()

--- a/tests/test_cli_agent_choices.py
+++ b/tests/test_cli_agent_choices.py
@@ -1,0 +1,10 @@
+"""Regression tests for coding-agent choices exposed by the main CLI."""
+
+from kapso.cli import AVAILABLE_AGENTS
+from kapso.execution.coding_agents.factory import CodingAgentFactory
+
+
+def test_codex_is_available_to_cli_and_factory():
+    """The CLI must accept every shipped, registered Codex adapter."""
+    assert "codex" in AVAILABLE_AGENTS
+    assert CodingAgentFactory.is_available("codex")


### PR DESCRIPTION
## Summary

- expose the already-registered `codex` adapter as a valid main CLI coding-agent choice
- add a regression test that keeps the CLI choices aligned with the factory registration

## Problem

`CodingAgentFactory` successfully registers the shipped Codex adapter, but `kapso evolve --coding-agent codex` is rejected by argparse because `codex` is missing from `AVAILABLE_AGENTS`. The same choices list is also used by `kapso deploy`.

## Validation

- `python -m pytest tests/test_cli_agent_choices.py -q` (`1 passed`)
- `python -m flake8 tests/test_cli_agent_choices.py`
- `kapso evolve --coding-agent codex --help`
- `git diff --check`

No model or API calls are required by the regression test.