### PR TITLE
benchmarks: READMEs link their rendered docs pages

### DIFF
--- a/benchmarks/ale/README.md
+++ b/benchmarks/ale/README.md
@@ -1,5 +1,7 @@
 # ALE-Bench Integration
 
+Rendered guide: [docs.leeroo.com/docs/benchmarks/ale-bench](https://docs.leeroo.com/docs/benchmarks/ale-bench) · Kapso by Leeroo: [github.com/Leeroo-AI/kapso](https://github.com/Leeroo-AI/kapso) · `pip install leeroo-kapso`
+
 This module provides integration with [ALE-Bench](https://github.com/SakanaAI/ALE-Bench), a benchmark for evaluating AI agents on AtCoder Heuristic Contests (algorithmic optimization problems).
 
 Kapso achieved **#1 on ALE-Bench**: a final rating of **1909 Elo** against ALE Agent's 1879

--- a/benchmarks/ioai2026/README.md
+++ b/benchmarks/ioai2026/README.md
@@ -1,5 +1,7 @@
 # IOAI 2026 Integration
 
+Rendered guide: [docs.leeroo.com/docs/benchmarks/ioai-2026](https://docs.leeroo.com/docs/benchmarks/ioai-2026) · Kapso by Leeroo: [github.com/Leeroo-AI/kapso](https://github.com/Leeroo-AI/kapso) · `pip install leeroo-kapso`
+
 Every summer the sharpest young AI minds on the planet sit the same exam. The
 [International Olympiad in Artificial Intelligence](https://ioai-official.org) is the IMO of
 the AI era: at IOAI 2026 in Astana, 471 contestants from 108 countries and territories

--- a/benchmarks/mle/README.md
+++ b/benchmarks/mle/README.md
@@ -1,5 +1,7 @@
 # MLE-Bench Integration
 
+Rendered guide: [docs.leeroo.com/docs/benchmarks/mle-bench](https://docs.leeroo.com/docs/benchmarks/mle-bench) · Kapso by Leeroo: [github.com/Leeroo-AI/kapso](https://github.com/Leeroo-AI/kapso) · `pip install leeroo-kapso`
+
 This module provides integration with [MLE-Bench](https://github.com/openai/mle-bench), OpenAI's benchmark for evaluating ML agents on Kaggle competitions.
 
 Kapso achieved **#1 among open-source systems** on this benchmark. These results were submitted as an [official submission to MLE-Bench](https://github.com/openai/mle-bench/pull/107).

--- a/benchmarks/relbench/README.md
+++ b/benchmarks/relbench/README.md
@@ -1,5 +1,7 @@
 # RelBench Integration
 
+Rendered guide: [docs.leeroo.com/docs/benchmarks/relbench](https://docs.leeroo.com/docs/benchmarks/relbench) · Kapso by Leeroo: [github.com/Leeroo-AI/kapso](https://github.com/Leeroo-AI/kapso) · `pip install leeroo-kapso`
+
 Every company's most valuable data has the same shape: customers, orders, events, and records
 spread across linked tables. [RelBench](https://relbench.stanford.edu) (Stanford/Kumo,
 [v2 paper](https://arxiv.org/abs/2602.12606)) turns that shape into a benchmark: 11 real


### PR DESCRIPTION
The four benchmark READMEs are already indexed and cited by coding agents for Kapso results; none linked the rendered guide. One line under each title: docs page, repository, install command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EerPsbgBogbtiztrtfVPLj