### PR TITLE
docs: doc-writer skill (house style for docs changes)

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -20,6 +20,12 @@
 # llms.txt because of exactly that.
 /*.md
 
+# Agent skills and editor config. Markdown, but not documentation: without
+# this the build parses them and `seo.indexing: all` publishes them as hidden
+# pages, the way CLAUDE.md once was.
+/.claude/
+/.agents/
+
 # Tracked, part of the package rather than the docs
 /src/
 /tests/

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,14 @@ Push to `main` and the site rebuilds itself — there is no deploy step to run a
 no machine of ours in the path. The only infrastructure we own is the DNS record
 pointing `docs.leeroo.com` at Mintlify.
 
+## How to write
+
+The house style — page anatomy, the Markdown rendition AI agents read, claims
+discipline, the closing Related and project lines, the checks — lives in the
+`doc-writer` skill at `.claude/skills/doc-writer/SKILL.md`. In Claude Code
+inside this repo it loads on its own; ask for `/doc-writer` or just start
+editing a page. Read it once even if you never use the agent.
+
 ## Change a page
 
 1. Edit the `.mdx` file.


### PR DESCRIPTION
A Claude Code skill at .claude/skills/doc-writer/SKILL.md: how to write and change docs pages, the README and benchmark READMEs — page anatomy, the Markdown rendition agents read, claims discipline, gates, post-merge check, release notes. .mintignore excludes /.claude/ and /.agents/ so skill files are never built as pages. docs/README.md points at it.

Local: check_docs_geo, check_docs_coverage, mint validate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EerPsbgBogbtiztrtfVPLj