### PR TITLE
docs: drop the dangling skill pointer in docs/README.md

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -20,9 +20,9 @@
 # llms.txt because of exactly that.
 /*.md
 
-# Agent skills and editor config. Markdown, but not documentation: without
-# this the build parses them and `seo.indexing: all` publishes them as hidden
-# pages, the way CLAUDE.md once was.
+# Editor and agent config directories. Any Markdown that lands here is not
+# documentation: without this the build parses it and `seo.indexing: all`
+# publishes it as a hidden page, the way CLAUDE.md once was.
 /.claude/
 /.agents/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,14 +5,6 @@ Push to `main` and the site rebuilds itself — there is no deploy step to run a
 no machine of ours in the path. The only infrastructure we own is the DNS record
 pointing `docs.leeroo.com` at Mintlify.
 
-## How to write
-
-The house style — page anatomy, the Markdown rendition AI agents read, claims
-discipline, the closing Related and project lines, the checks — lives in the
-`doc-writer` skill at `.claude/skills/doc-writer/SKILL.md`. In Claude Code
-inside this repo it loads on its own; ask for `/doc-writer` or just start
-editing a page. Read it once even if you never use the agent.
-
 ## Change a page
 
 1. Edit the `.mdx` file.


### PR DESCRIPTION
Removes the "How to write" pointer added in #97: the skill file it referenced is kept outside this repo. The .mintignore exclusion of /.claude/ and /.agents/ stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EerPsbgBogbtiztrtfVPLj