### PR TITLE
docs(overview): what Kapso is

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,17 +1,15 @@
 ---
 title: "Kapso: a self-improving AI factory for measurable goals"
 sidebarTitle: "What is Kapso"
-description: "Kapso, by Leeroo, builds software for goals you can score. It runs experiment campaigns, banks what it learns from each one, and ships the winner to your infrastructure."
+description: "Kapso, by Leeroo, is a self-improving software factory. State an objective and it runs a campaign of candidate solutions, refining the closest until the objective is met, and it learns from every campaign it finishes."
 keywords: ["Kapso", "AI software factory", "automated ML", "experiment campaigns", "self-improving agent", "MLE-Bench", "RelBench"]
 ---
 
-Kapso builds software for goals you can measure.
+Kapso is a self-improving software factory. State an objective and it runs a campaign: it designs candidate solutions, has coding agents implement them, measures how far each one is from the objective, and keeps refining the closest until the objective is met. The result ships to your infrastructure.
 
-Kapso is an open-source Python framework by [Leeroo](https://leeroo.com). The source lives at [github.com/Leeroo-AI/kapso](https://github.com/Leeroo-AI/kapso) and the package installs with `pip install leeroo-kapso`. It is unrelated to the WhatsApp developer platform that shares the name.
+The factory improves with use. When a campaign ends, Kapso studies its own work: which ideas closed the distance to the objective, which did not, and under what conditions. Each finding is kept as a lesson with the evidence that earned it, and a lesson stays trusted only as long as it keeps holding up. Kapso also reads outside your walls, repositories and papers, and folds what it finds into the same knowledge hub. Every new campaign begins from that hub, so it starts with what earlier work already established, about the problem and about your systems.
 
-Give it a goal. It runs **experiment campaigns**: designing candidates, implementing them, scoring each one, and refining the best. Every claim of progress is a score, and the winner ships to your infrastructure.
-
-The factory is **self-improving** because it learns from its own work. Finished campaigns become evidence-priced lessons. It also learns from public knowledge, including repositories and papers. Everything compounds in one knowledge hub, so each campaign starts where the last one left off.
+Kapso is an open-source Python framework by [Leeroo](https://leeroo.com). The source lives at [github.com/Leeroo-AI/kapso](https://github.com/Leeroo-AI/kapso) and the package installs with `pip install leeroo-kapso`.
 
 ## The four pillars
 


### PR DESCRIPTION
Brings the docs overview in line with the README section merged in #99: the factory described by an objective and the distance to it, a fuller account of how it improves with use, the frontmatter description in the same terms. Removes the WhatsApp disambiguation sentence.

Local: check_docs_geo and mint validate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EerPsbgBogbtiztrtfVPLj