### PR TITLE
README: main docs sections in Documentation & Support; PyPI project URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ Each benchmark also has a documentation page covering how to run it, its CLI opt
   - [Python API](https://docs.leeroo.com/docs/reference/kapso-api) — every public method on `Kapso`
   - [Configuration](https://docs.leeroo.com/docs/reference/configuration) — every key in `config.yaml`
   - [Trajectory learning](https://docs.leeroo.com/docs/learning/overview) — the lesson bank, grading and serving
+  - [Evolve](https://docs.leeroo.com/docs/evolve/overview) — how a campaign runs, and [what happens inside one experiment](https://docs.leeroo.com/docs/evolve/execution-flow)
+  - [Knowledge graph](https://docs.leeroo.com/docs/knowledge/overview) — repositories and papers turned into searchable knowledge
+  - [Deployment](https://docs.leeroo.com/docs/deployment/overview) — local, Docker, Modal and the other strategies
+  - [Kapso skill for coding agents](https://docs.leeroo.com/docs/coding-agent-skills) — launch and resume campaigns from Claude Code, Codex or OpenCode
 - **From your coding agent**: the docs run an MCP server at `https://docs.leeroo.com/mcp`, and every page is served as Markdown — see [llms.txt](https://docs.leeroo.com/llms.txt) and [Docs in your coding agent](https://docs.leeroo.com/docs/agent-access).
   ```bash
   claude mcp add --transport http kapso-docs https://docs.leeroo.com/mcp   # Claude Code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,11 @@ expert-relbench = "benchmarks.relbench.runner:main"
 
 [project.urls]
 Homepage = "https://leeroo.com"
-Documentation = "https://docs.leeroo.com"
+Documentation = "https://docs.leeroo.com/docs"
+Quickstart = "https://docs.leeroo.com/docs/quickstart"
+Benchmarks = "https://docs.leeroo.com/docs/benchmarks/mle-bench"
+"Docs in your coding agent" = "https://docs.leeroo.com/docs/agent-access"
+Changelog = "https://github.com/Leeroo-AI/kapso/releases"
 Repository = "https://github.com/leeroo-ai/kapso"
 Issues = "https://github.com/leeroo-ai/kapso/issues"
 


### PR DESCRIPTION
Adds four bullets to the README Documentation & Support list (Evolve + execution flow, Knowledge graph, Deployment, Kapso skill for coding agents) so every top-level docs section is linked, and extends pyproject project URLs (Documentation → /docs, Quickstart, Benchmarks, agent access, Changelog), which PyPI shows as sidebar links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)