### PR TITLE
docs: page map in docs/README.md; README links the docs at /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h4 align="center">A Self-Improving AI Software Factory (for Measurable Objectives)</h4>
 
 <p align="center">
-  <a href="https://docs.leeroo.com">Learn more</a> ·
+  <a href="https://docs.leeroo.com/docs">Learn more</a> ·
   <a href="https://discord.gg/hqVbPNNEZM">Join Discord</a> ·
   <a href="https://leeroo.com">Website</a>
 </p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,77 @@ npx mint@4 broken-links   # what CI runs
   also matches `docs/benchmarks/` and silently unpublishes those pages.
 - **There are no PR preview deployments** on the current plan. CI passing is the
   only signal you get before a change is live, so read it.
+
+## Pages
+
+Every published page with its rendered address, grouped as in the sidebar. Kept here so the folder listing on GitHub points at the site.
+
+**Getting started**
+
+- [What is Kapso](https://docs.leeroo.com/docs) — `docs/index.mdx`
+- [Install Kapso and verify your setup with kapso doctor](https://docs.leeroo.com/docs/installation) — `docs/installation.mdx`
+- [Run your first Kapso campaign in under ten minutes](https://docs.leeroo.com/docs/quickstart) — `docs/quickstart.mdx`
+- [Docs in your coding agent](https://docs.leeroo.com/docs/agent-access) — `docs/agent-access.mdx`
+- [Kapso skill for coding agents](https://docs.leeroo.com/docs/coding-agent-skills) — `docs/coding-agent-skills.mdx`
+
+**Evolve system**
+
+- [Overview](https://docs.leeroo.com/docs/evolve/overview) — `docs/evolve/overview.mdx`
+- [Architecture](https://docs.leeroo.com/docs/evolve/architecture) — `docs/evolve/architecture.mdx`
+- [Execution flow](https://docs.leeroo.com/docs/evolve/execution-flow) — `docs/evolve/execution-flow.mdx`
+- [Resuming runs](https://docs.leeroo.com/docs/evolve/resuming-runs) — `docs/evolve/resuming-runs.mdx`
+- [Inbox](https://docs.leeroo.com/docs/evolve/inbox) — `docs/evolve/inbox.mdx`
+- [External evaluation](https://docs.leeroo.com/docs/evolve/external-evaluation) — `docs/evolve/external-evaluation.mdx`
+- [Evaluation integrity](https://docs.leeroo.com/docs/evolve/evaluation-integrity) — `docs/evolve/evaluation-integrity.mdx`
+
+*Components*
+
+- [Orchestrator](https://docs.leeroo.com/docs/evolve/orchestrator) — `docs/evolve/orchestrator.mdx`
+- [Search strategies](https://docs.leeroo.com/docs/evolve/search-strategies) — `docs/evolve/search-strategies.mdx`
+- [Parent selection](https://docs.leeroo.com/docs/evolve/parent-selection) — `docs/evolve/parent-selection.mdx`
+- [MCP gates](https://docs.leeroo.com/docs/evolve/mcp-gates) — `docs/evolve/mcp-gates.mdx`
+- [Model routing](https://docs.leeroo.com/docs/evolve/model-routing-retries) — `docs/evolve/model-routing-retries.mdx`
+- [Coding agents](https://docs.leeroo.com/docs/evolve/coding-agents) — `docs/evolve/coding-agents.mdx`
+- [Feedback generator](https://docs.leeroo.com/docs/evolve/feedback-generator) — `docs/evolve/feedback-generator.mdx`
+- [Experiment lifecycle](https://docs.leeroo.com/docs/evolve/experiment-lifecycle) — `docs/evolve/experiment-lifecycle.mdx`
+- [Repo memory](https://docs.leeroo.com/docs/evolve/repo-memory) — `docs/evolve/repo-memory.mdx`
+
+**Knowledge graph**
+
+- [Knowledge graph](https://docs.leeroo.com/docs/knowledge/overview) — `docs/knowledge/overview.mdx`
+- [Learning pipeline](https://docs.leeroo.com/docs/knowledge/learning-pipeline) — `docs/knowledge/learning-pipeline.mdx`
+- [Search backends](https://docs.leeroo.com/docs/knowledge/search-backends) — `docs/knowledge/search-backends.mdx`
+
+**Trajectory learning**
+
+- [Overview](https://docs.leeroo.com/docs/learning/overview) — `docs/learning/overview.mdx`
+- [The lesson bank](https://docs.leeroo.com/docs/learning/bank) — `docs/learning/bank.mdx`
+- [The pipeline](https://docs.leeroo.com/docs/learning/pipeline) — `docs/learning/pipeline.mdx`
+- [Grading](https://docs.leeroo.com/docs/learning/graders) — `docs/learning/graders.mdx`
+- [Serving](https://docs.leeroo.com/docs/learning/serving) — `docs/learning/serving.mdx`
+- [Development regime](https://docs.leeroo.com/docs/learning/development) — `docs/learning/development.mdx`
+
+**Research**
+
+- [Deep web research](https://docs.leeroo.com/docs/research/overview) — `docs/research/overview.mdx`
+
+**Deployment**
+
+- [Deployment](https://docs.leeroo.com/docs/deployment/overview) — `docs/deployment/overview.mdx`
+- [Deployment architecture](https://docs.leeroo.com/docs/deployment/architecture) — `docs/deployment/architecture.mdx`
+- [Deployment strategies](https://docs.leeroo.com/docs/deployment/strategies) — `docs/deployment/strategies.mdx`
+- [Adding strategies](https://docs.leeroo.com/docs/deployment/adding-strategies) — `docs/deployment/adding-strategies.mdx`
+
+**Benchmarks**
+
+- [IOAI 2026](https://docs.leeroo.com/docs/benchmarks/ioai-2026) — `docs/benchmarks/ioai-2026.mdx`
+- [MLE-Bench](https://docs.leeroo.com/docs/benchmarks/mle-bench) — `docs/benchmarks/mle-bench.mdx`
+- [ALE-Bench](https://docs.leeroo.com/docs/benchmarks/ale-bench) — `docs/benchmarks/ale-bench.mdx`
+- [RelBench](https://docs.leeroo.com/docs/benchmarks/relbench) — `docs/benchmarks/relbench.mdx`
+
+**Reference**
+
+- [CLI](https://docs.leeroo.com/docs/reference/cli) — `docs/reference/cli.mdx`
+- [Python API](https://docs.leeroo.com/docs/reference/kapso-api) — `docs/reference/kapso-api.mdx`
+- [Deployment API](https://docs.leeroo.com/docs/deployment/api-reference) — `docs/deployment/api-reference.mdx`
+- [Configuration](https://docs.leeroo.com/docs/reference/configuration) — `docs/reference/configuration.mdx`


### PR DESCRIPTION
Two small things for search discovery of the docs site:

- `docs/README.md` (the contributor file GitHub shows on the docs/ folder page, which the indexes already hold) ends with a **Pages** section listing all 43 pages with their rendered docs.leeroo.com addresses, grouped as in the sidebar. The main README is unchanged in length.
- The README links that pointed at the bare `https://docs.leeroo.com` now point at `/docs`: the root answers 308, and Brave's verification fetch rejects redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)