### PR TITLE
docs: redirects for pages removed in past restructures

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -126,6 +126,30 @@
     ]
   },
 
+  "redirects": [
+    { "source": "/docs/evolve/reliability-roadmap", "destination": "/docs/evolve/overview" },
+    { "source": "/docs/evolve/cognitive-memory", "destination": "/docs/learning/overview" },
+    { "source": "/docs/evolve/budget-aware-experimentation", "destination": "/docs/evolve/overview" },
+    { "source": "/docs/evolve/evaluators", "destination": "/docs/evolve/external-evaluation" },
+    { "source": "/docs/evolve/stop-conditions", "destination": "/docs/evolve/overview" },
+    { "source": "/docs/concepts/execution-flow", "destination": "/docs/evolve/execution-flow" },
+    { "source": "/docs/concepts/tree-search", "destination": "/docs/evolve/search-strategies" },
+    { "source": "/docs/concepts/architecture", "destination": "/docs/evolve/architecture" },
+    { "source": "/docs/concepts/experiment-lifecycle", "destination": "/docs/evolve/experiment-lifecycle" },
+    { "source": "/docs/concepts/kapso-api", "destination": "/docs/reference/kapso-api" },
+    { "source": "/docs/concepts/tinkerer-api", "destination": "/docs/reference/kapso-api" },
+    { "source": "/docs/concepts/knowledge-system", "destination": "/docs/knowledge/overview" },
+    { "source": "/docs/components/orchestrator", "destination": "/docs/evolve/orchestrator" },
+    { "source": "/docs/components/coding-agents/overview", "destination": "/docs/evolve/coding-agents" },
+    { "source": "/docs/components/search-strategies/overview", "destination": "/docs/evolve/search-strategies" },
+    { "source": "/docs/components/knowledge-search/overview", "destination": "/docs/knowledge/search-backends" },
+    { "source": "/docs/components/wiki-mcp/overview", "destination": "/docs/knowledge/overview" },
+    { "source": "/docs/guides/configuration", "destination": "/docs/reference/configuration" },
+    { "source": "/docs/guides/setup-neo4j", "destination": "/docs/installation" },
+    { "source": "/docs/knowledge/wiki-structure", "destination": "/docs/knowledge/overview" },
+    { "source": "/docs/benchmarks/generic-problems", "destination": "/docs/benchmarks/mle-bench" }
+  ],
+
   "footer": {
     "socials": {
     "github": "https://github.com/leeroo-ai/kapso"


### PR DESCRIPTION
Adds a `redirects` block to `docs.json` — 21 entries, one per docs page removed since January, each pointing at the live page covering the same ground. No page content changes; 24 lines added, none removed.

**Why.** Search engines still hold URLs the site no longer serves:

- `/docs/evolve/reliability-roadmap` (unpublished 09-01) is **indexed by Google with 28 impressions at average position 5.0** over the last 28 days, and returns 404. It is one of only four docs URLs Google indexes at all.
- Bing recrawled that same URL on 09-09 and stored the 404 body (571 KB); `/docs/evolve/cognitive-memory`, removed in January, is in the same state (crawled 08-25).
- Bing is currently recrawling this site at roughly two pages a day, so dead URLs consume a meaningful share of the budget.

Mintlify serves redirects as 308 permanent by default, so both engines can retire the dead URLs and carry their history to the current pages.

Every destination was checked to exist in the navigation, and no source is a live page. `mint validate` and `check_docs_geo.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1uzVjth8N9qyFwDMwuTLG